### PR TITLE
Remove the need to specify currentVersion

### DIFF
--- a/community/docs/antora.yml
+++ b/community/docs/antora.yml
@@ -6,7 +6,6 @@ nav:
   - modules/ROOT/nav.adoc
 asciidoc:
   attributes:
-    currentVersion: '5.2022.1'
     glassfishVersion: '5'
     payaraWebDtd: 'https://docs.payara.fish/schemas/payara-web-app_4.dtd'
     payaraResourcesDtd: 'https://raw.githubusercontent.com/payara/Payara-Community-Documentation/master/docs/modules/ROOT/pages/schemas/payara-resources_1_6.dtd'

--- a/community/docs/modules/ROOT/nav.adoc
+++ b/community/docs/modules/ROOT/nav.adoc
@@ -7,7 +7,6 @@
 * xref:General Info/Contributing To Payara.adoc[Contributing To Payara]
 
 .Technical Documentation
-* xref:Technical Documentation/Test.adoc[Test]
 * Payara Micro Documentation
 ** xref:Technical Documentation/Payara Micro Documentation/Overview.adoc[Overview]
 ** xref:Technical Documentation/Payara Micro Documentation/Maven Support.adoc[Maven Support]

--- a/community/docs/modules/ROOT/nav.adoc
+++ b/community/docs/modules/ROOT/nav.adoc
@@ -1,260 +1,261 @@
 
 .General Info
 * xref:General Info/Overview.adoc[Overview]
-* xref:General Info/Build Instructions.adoc[Build Instructions]
-* xref:General Info/Contributing To Payara.adoc[Contributing To Payara]
 * xref:General Info/Getting Started.adoc[Getting Started]
+* xref:General Info/Build Instructions.adoc[Build Instructions]
 * xref:General Info/Supported Platforms.adoc[Supported Platforms]
+* xref:General Info/Contributing To Payara.adoc[Contributing To Payara]
 
 .Technical Documentation
-* Ecosystem
-** xref:Technical Documentation/Ecosystem/Overview.adoc[Overview]
-** Connector Suites
-*** xref:Technical Documentation/Ecosystem/Connector Suites/Security Connectors.adoc[Security Connectors]
-*** Arquillian Containers
-**** xref:Technical Documentation/Ecosystem/Connector Suites/Arquillian Containers/Overview.adoc[Overview]
-**** xref:Technical Documentation/Ecosystem/Connector Suites/Arquillian Containers/Payara Micro Managed.adoc[Payara Micro Managed]
-**** xref:Technical Documentation/Ecosystem/Connector Suites/Arquillian Containers/Payara Server Embedded.adoc[Payara Server Embedded]
-**** xref:Technical Documentation/Ecosystem/Connector Suites/Arquillian Containers/Payara Server Managed.adoc[Payara Server Managed]
-**** xref:Technical Documentation/Ecosystem/Connector Suites/Arquillian Containers/Payara Server Remote.adoc[Payara Server Remote]
-*** Cloud Connectors
-**** xref:Technical Documentation/Ecosystem/Connector Suites/Cloud Connectors/Overview.adoc[Overview]
-**** xref:Technical Documentation/Ecosystem/Connector Suites/Cloud Connectors/Amazon SQS.adoc[Amazon SQS]
-**** xref:Technical Documentation/Ecosystem/Connector Suites/Cloud Connectors/Apache Kafka.adoc[Apache Kafka]
-**** xref:Technical Documentation/Ecosystem/Connector Suites/Cloud Connectors/Azure SB.adoc[Azure SB]
-**** xref:Technical Documentation/Ecosystem/Connector Suites/Cloud Connectors/MQTT.adoc[MQTT]
-** IDE Integration
-*** Eclipse Plugin
-**** xref:Technical Documentation/Ecosystem/IDE Integration/Eclipse Plugin/Overview.adoc[Overview]
-**** xref:Technical Documentation/Ecosystem/IDE Integration/Eclipse Plugin/Payara Micro.adoc[Payara Micro]
-**** xref:Technical Documentation/Ecosystem/IDE Integration/Eclipse Plugin/Payara Server.adoc[Payara Server]
-*** Intellij Plugin
-**** xref:Technical Documentation/Ecosystem/IDE Integration/Intellij Plugin/Overview.adoc[Overview]
-**** xref:Technical Documentation/Ecosystem/IDE Integration/Intellij Plugin/Payara Micro.adoc[Payara Micro]
-**** xref:Technical Documentation/Ecosystem/IDE Integration/Intellij Plugin/Payara Server.adoc[Payara Server]
-*** NetBeans Plugin
-**** xref:Technical Documentation/Ecosystem/IDE Integration/NetBeans Plugin/Overview.adoc[Overview]
-**** xref:Technical Documentation/Ecosystem/IDE Integration/NetBeans Plugin/Payara Micro.adoc[Payara Micro]
-**** xref:Technical Documentation/Ecosystem/IDE Integration/NetBeans Plugin/Payara Server.adoc[Payara Server]
-*** VSCode Extension
-**** xref:Technical Documentation/Ecosystem/IDE Integration/VSCode Extension/Overview.adoc[Overview]
-**** xref:Technical Documentation/Ecosystem/IDE Integration/VSCode Extension/Payara Micro.adoc[Payara Micro]
-**** xref:Technical Documentation/Ecosystem/IDE Integration/VSCode Extension/Payara Server.adoc[Payara Server]
-** Miscellaneous
-*** xref:Technical Documentation/Ecosystem/Miscellaneous/JAX-RS Extension.adoc[JAX-RS Extension]
-** Project Management Tools
-*** xref:Technical Documentation/Ecosystem/Project Management Tools/Gradle Plugin.adoc[Gradle Plugin]
-*** xref:Technical Documentation/Ecosystem/Project Management Tools/Maven Archetype.adoc[Maven Archetype]
-*** xref:Technical Documentation/Ecosystem/Project Management Tools/Maven Bom.adoc[Maven Bom]
-*** xref:Technical Documentation/Ecosystem/Project Management Tools/Maven Plugin.adoc[Maven Plugin]
-* MicroProfile
-** xref:Technical Documentation/MicroProfile/Overview.adoc[Overview]
-** xref:Technical Documentation/MicroProfile/JWT.adoc[JWT]
-** xref:Technical Documentation/MicroProfile/Rest Client.adoc[Rest Client]
-** xref:Technical Documentation/MicroProfile/Fault Tolerance.adoc[Fault Tolerance]
-** xref:Technical Documentation/MicroProfile/HealthCheck.adoc[HealthCheck]
-** xref:Technical Documentation/MicroProfile/OpenAPI.adoc[OpenAPI]
-** xref:Technical Documentation/MicroProfile/Opentracing.adoc[Opentracing]
-** Config
-*** xref:Technical Documentation/MicroProfile/Config/Overview.adoc[Overview]
-*** xref:Technical Documentation/MicroProfile/Config/Directory.adoc[Directory]
-*** xref:Technical Documentation/MicroProfile/Config/JDBC.adoc[JDBC]
-*** xref:Technical Documentation/MicroProfile/Config/LDAP.adoc[LDAP]
-*** Cloud
-**** xref:Technical Documentation/MicroProfile/Config/Cloud/Overview.adoc[Overview]
-**** xref:Technical Documentation/MicroProfile/Config/Cloud/AWS.adoc[AWS]
-**** xref:Technical Documentation/MicroProfile/Config/Cloud/DynamoDB.adoc[DynamoDB]
-**** xref:Technical Documentation/MicroProfile/Config/Cloud/GCP.adoc[GCP]
-**** xref:Technical Documentation/MicroProfile/Config/Cloud/Hashicorp.adoc[Hashicorp]
-**** xref:Technical Documentation/MicroProfile/Config/Cloud/Azure.adoc[Azure]
-** Metrics
-*** xref:Technical Documentation/MicroProfile/Metrics/Metrics Configuration.adoc[Metrics Configuration]
-*** xref:Technical Documentation/MicroProfile/Metrics/Metrics Rest Endpoint.adoc[Metrics Rest Endpoint]
-*** xref:Technical Documentation/MicroProfile/Metrics/Vendor Metrics.adoc[Vendor Metrics]
+* xref:Technical Documentation/Test.adoc[Test]
 * Payara Micro Documentation
 ** xref:Technical Documentation/Payara Micro Documentation/Overview.adoc[Overview]
 ** xref:Technical Documentation/Payara Micro Documentation/Maven Support.adoc[Maven Support]
 ** xref:Technical Documentation/Payara Micro Documentation/Payara Micro Docker Image.adoc[Payara Micro Docker Image]
-** API
-*** xref:Technical Documentation/Payara Micro Documentation/API/JCache in Payara Micro.adoc[JCache in Payara Micro]
-*** Payara Micro API
-**** xref:Technical Documentation/Payara Micro Documentation/API/Payara Micro API/Overview.adoc[Overview]
-**** xref:Technical Documentation/Payara Micro Documentation/API/Payara Micro API/Using the Payara Micro API.adoc[Using the Payara Micro API]
 ** Extensions
-*** xref:Technical Documentation/Payara Micro Documentation/Extensions/JCA Support.adoc[JCA Support]
 *** xref:Technical Documentation/Payara Micro Documentation/Extensions/Persistent EJB Timers.adoc[Persistent EJB Timers]
 *** xref:Technical Documentation/Payara Micro Documentation/Extensions/Remote CDI Events.adoc[Remote CDI Events]
 *** xref:Technical Documentation/Payara Micro Documentation/Extensions/Running Callable Objects.adoc[Running Callable Objects]
+*** xref:Technical Documentation/Payara Micro Documentation/Extensions/JCA Support.adoc[JCA Support]
+** Payara Micro Configuration and Management
+*** Micro Management
+**** xref:Technical Documentation/Payara Micro Documentation/Payara Micro Configuration and Management/Micro Management/Configuring An Instance.adoc[Configuring An Instance]
+**** xref:Technical Documentation/Payara Micro Documentation/Payara Micro Configuration and Management/Micro Management/Clustering.adoc[Clustering]
+**** xref:Technical Documentation/Payara Micro Documentation/Payara Micro Configuration and Management/Micro Management/HTTP(S) Auto-Binding.adoc[HTTP(S) Auto-Binding]
+**** Jar Structure and Configuration
+***** xref:Technical Documentation/Payara Micro Documentation/Payara Micro Configuration and Management/Micro Management/Jar Structure and Configuration/Payara Micro Jar Structure.adoc[Payara Micro Jar Structure]
+***** xref:Technical Documentation/Payara Micro Documentation/Payara Micro Configuration and Management/Micro Management/Jar Structure and Configuration/Root Directory.adoc[Root Directory]
+***** xref:Technical Documentation/Payara Micro Documentation/Payara Micro Configuration and Management/Micro Management/Jar Structure and Configuration/Adding Jars.adoc[Adding Jars]
+**** Stopping and Starting Instances
+***** xref:Technical Documentation/Payara Micro Documentation/Payara Micro Configuration and Management/Micro Management/Stopping and Starting Instances/Stopping Instance.adoc[Stopping Instance]
+***** xref:Technical Documentation/Payara Micro Documentation/Payara Micro Configuration and Management/Micro Management/Stopping and Starting Instances/Starting Instance.adoc[Starting Instance]
+**** Deploying Applications
+***** xref:Technical Documentation/Payara Micro Documentation/Payara Micro Configuration and Management/Micro Management/Deploying Applications/Deploy Applications Programmatically.adoc[Deploy Applications Programmatically]
+***** xref:Technical Documentation/Payara Micro Documentation/Payara Micro Configuration and Management/Micro Management/Deploying Applications/Deploy Applications.adoc[Deploy Applications]
+**** Command Line Options
+***** xref:Technical Documentation/Payara Micro Documentation/Payara Micro Configuration and Management/Micro Management/Command Line Options/Disable Phone Home.adoc[Disable Phone Home]
+***** xref:Technical Documentation/Payara Micro Documentation/Payara Micro Configuration and Management/Micro Management/Command Line Options/Command Line Options.adoc[Command Line Options]
+**** Asadmin Commands
+***** xref:Technical Documentation/Payara Micro Documentation/Payara Micro Configuration and Management/Micro Management/Asadmin Commands/Send Asadmin Commands from Admin Console.adoc[Send Asadmin Commands from Admin Console]
+***** xref:Technical Documentation/Payara Micro Documentation/Payara Micro Configuration and Management/Micro Management/Asadmin Commands/Pre and Post Boot Commands.adoc[Pre and Post Boot Commands]
+*** Database Management
+**** xref:Technical Documentation/Payara Micro Documentation/Payara Micro Configuration and Management/Database Management/Slow SQL Logger.adoc[Slow SQL Logger]
+**** xref:Technical Documentation/Payara Micro Documentation/Payara Micro Configuration and Management/Database Management/Log JDBC Calls.adoc[Log JDBC Calls]
+**** xref:Technical Documentation/Payara Micro Documentation/Payara Micro Configuration and Management/Database Management/SQL Trace Listeners.adoc[SQL Trace Listeners]
 ** Logging and Monitoring
 *** xref:Technical Documentation/Payara Micro Documentation/Logging and Monitoring/Request Tracing.adoc[Request Tracing]
 *** Logging
 **** xref:Technical Documentation/Payara Micro Documentation/Logging and Monitoring/Logging/Config Access Log.adoc[Config Access Log]
 **** xref:Technical Documentation/Payara Micro Documentation/Logging and Monitoring/Logging/Logging to File.adoc[Logging to File]
-** Payara Micro Configuration and Management
-*** Database Management
-**** xref:Technical Documentation/Payara Micro Documentation/Payara Micro Configuration and Management/Database Management/Log JDBC Calls.adoc[Log JDBC Calls]
-**** xref:Technical Documentation/Payara Micro Documentation/Payara Micro Configuration and Management/Database Management/Slow SQL Logger.adoc[Slow SQL Logger]
-**** xref:Technical Documentation/Payara Micro Documentation/Payara Micro Configuration and Management/Database Management/SQL Trace Listeners.adoc[SQL Trace Listeners]
-*** Micro Management
-**** xref:Technical Documentation/Payara Micro Documentation/Payara Micro Configuration and Management/Micro Management/Clustering.adoc[Clustering]
-**** xref:Technical Documentation/Payara Micro Documentation/Payara Micro Configuration and Management/Micro Management/Configuring An Instance.adoc[Configuring An Instance]
-**** xref:Technical Documentation/Payara Micro Documentation/Payara Micro Configuration and Management/Micro Management/HTTP(S) Auto-Binding.adoc[HTTP(S) Auto-Binding]
-**** Asadmin Commands
-***** xref:Technical Documentation/Payara Micro Documentation/Payara Micro Configuration and Management/Micro Management/Asadmin Commands/Pre and Post Boot Commands.adoc[Pre and Post Boot Commands]
-***** xref:Technical Documentation/Payara Micro Documentation/Payara Micro Configuration and Management/Micro Management/Asadmin Commands/Send Asadmin Commands from Admin Console.adoc[Send Asadmin Commands from Admin Console]
-**** Command Line Options
-***** xref:Technical Documentation/Payara Micro Documentation/Payara Micro Configuration and Management/Micro Management/Command Line Options/Command Line Options.adoc[Command Line Options]
-***** xref:Technical Documentation/Payara Micro Documentation/Payara Micro Configuration and Management/Micro Management/Command Line Options/Disable Phone Home.adoc[Disable Phone Home]
-**** Deploying Applications
-***** xref:Technical Documentation/Payara Micro Documentation/Payara Micro Configuration and Management/Micro Management/Deploying Applications/Deploy Applications Programmatically.adoc[Deploy Applications Programmatically]
-***** xref:Technical Documentation/Payara Micro Documentation/Payara Micro Configuration and Management/Micro Management/Deploying Applications/Deploy Applications.adoc[Deploy Applications]
-**** Jar Structure and Configuration
-***** xref:Technical Documentation/Payara Micro Documentation/Payara Micro Configuration and Management/Micro Management/Jar Structure and Configuration/Adding Jars.adoc[Adding Jars]
-***** xref:Technical Documentation/Payara Micro Documentation/Payara Micro Configuration and Management/Micro Management/Jar Structure and Configuration/Payara Micro Jar Structure.adoc[Payara Micro Jar Structure]
-***** xref:Technical Documentation/Payara Micro Documentation/Payara Micro Configuration and Management/Micro Management/Jar Structure and Configuration/Root Directory.adoc[Root Directory]
-**** Stopping and Starting Instances
-***** xref:Technical Documentation/Payara Micro Documentation/Payara Micro Configuration and Management/Micro Management/Stopping and Starting Instances/Starting Instance.adoc[Starting Instance]
-***** xref:Technical Documentation/Payara Micro Documentation/Payara Micro Configuration and Management/Micro Management/Stopping and Starting Instances/Stopping Instance.adoc[Stopping Instance]
+** API
+*** xref:Technical Documentation/Payara Micro Documentation/API/JCache in Payara Micro.adoc[JCache in Payara Micro]
+*** Payara Micro API
+**** xref:Technical Documentation/Payara Micro Documentation/API/Payara Micro API/Overview.adoc[Overview]
+**** xref:Technical Documentation/Payara Micro Documentation/API/Payara Micro API/Using the Payara Micro API.adoc[Using the Payara Micro API]
 * Payara Server Documentation
 ** xref:Technical Documentation/Payara Server Documentation/Overview.adoc[Overview]
 ** xref:Technical Documentation/Payara Server Documentation/Payara Server Docker Image.adoc[Payara Server Docker Image]
-** Deployment Groups
-*** xref:Technical Documentation/Payara Server Documentation/Deployment Groups/Overview.adoc[Overview]
-*** xref:Technical Documentation/Payara Server Documentation/Deployment Groups/Asadmin Commands.adoc[Asadmin Commands]
-*** xref:Technical Documentation/Payara Server Documentation/Deployment Groups/Timers.adoc[Timers]
-** Development Debugging And Assistance Tools
-*** xref:Technical Documentation/Payara Server Documentation/Development Debugging And Assistance Tools/CDI.adoc[CDI]
 ** Extensions
 *** xref:Technical Documentation/Payara Server Documentation/Extensions/Overview.adoc[Overview]
-*** Notifiers
-**** xref:Technical Documentation/Payara Server Documentation/Extensions/Notifiers/Overview.adoc[Overview]
-**** xref:Technical Documentation/Payara Server Documentation/Extensions/Notifiers/Custom Notifiers.adoc[Custom Notifiers]
-**** xref:Technical Documentation/Payara Server Documentation/Extensions/Notifiers/Datadog.adoc[Datadog]
-**** xref:Technical Documentation/Payara Server Documentation/Extensions/Notifiers/Discord.adoc[Discord]
-**** xref:Technical Documentation/Payara Server Documentation/Extensions/Notifiers/Email.adoc[Email]
-**** xref:Technical Documentation/Payara Server Documentation/Extensions/Notifiers/MS Teams.adoc[MS Teams]
-**** xref:Technical Documentation/Payara Server Documentation/Extensions/Notifiers/New Relic.adoc[New Relic]
-**** xref:Technical Documentation/Payara Server Documentation/Extensions/Notifiers/Slack.adoc[Slack]
-**** xref:Technical Documentation/Payara Server Documentation/Extensions/Notifiers/SNMP.adoc[SNMP]
-**** xref:Technical Documentation/Payara Server Documentation/Extensions/Notifiers/XMPP.adoc[XMPP]
 *** AutoScale Groups
 **** xref:Technical Documentation/Payara Server Documentation/Extensions/AutoScale Groups/Overview.adoc[Overview]
-**** xref:Technical Documentation/Payara Server Documentation/Extensions/AutoScale Groups/Create AutoScale Group.adoc[Create AutoScale Group]
 **** xref:Technical Documentation/Payara Server Documentation/Extensions/AutoScale Groups/Nodes Scaling Group.adoc[Nodes Scaling Group]
+**** xref:Technical Documentation/Payara Server Documentation/Extensions/AutoScale Groups/Create AutoScale Group.adoc[Create AutoScale Group]
+*** Notifiers
+**** xref:Technical Documentation/Payara Server Documentation/Extensions/Notifiers/Overview.adoc[Overview]
+**** xref:Technical Documentation/Payara Server Documentation/Extensions/Notifiers/Discord.adoc[Discord]
+**** xref:Technical Documentation/Payara Server Documentation/Extensions/Notifiers/Custom Notifiers.adoc[Custom Notifiers]
+**** xref:Technical Documentation/Payara Server Documentation/Extensions/Notifiers/Slack.adoc[Slack]
+**** xref:Technical Documentation/Payara Server Documentation/Extensions/Notifiers/Email.adoc[Email]
+**** xref:Technical Documentation/Payara Server Documentation/Extensions/Notifiers/SNMP.adoc[SNMP]
+**** xref:Technical Documentation/Payara Server Documentation/Extensions/Notifiers/New Relic.adoc[New Relic]
+**** xref:Technical Documentation/Payara Server Documentation/Extensions/Notifiers/XMPP.adoc[XMPP]
+**** xref:Technical Documentation/Payara Server Documentation/Extensions/Notifiers/Datadog.adoc[Datadog]
+**** xref:Technical Documentation/Payara Server Documentation/Extensions/Notifiers/MS Teams.adoc[MS Teams]
 *** gRPC Support
 **** xref:Technical Documentation/Payara Server Documentation/Extensions/gRPC Support/Overview.adoc[Overview]
 **** xref:Technical Documentation/Payara Server Documentation/Extensions/gRPC Support/Usage.adoc[Usage]
 **** xref:Technical Documentation/Payara Server Documentation/Extensions/gRPC Support/Installation.adoc[Installation]
+** Development Debugging And Assistance Tools
+*** xref:Technical Documentation/Payara Server Documentation/Development Debugging And Assistance Tools/CDI.adoc[CDI]
+** Server Configuration And Management
+*** JDBC Resource Management
+**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/JDBC Resource Management/JDBC.adoc[JDBC]
+**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/JDBC Resource Management/SQL.adoc[SQL]
+*** Admin Console Enhancements
+**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Admin Console Enhancements/Overview.adoc[Overview]
+**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Admin Console Enhancements/Auditing Service.adoc[Auditing Service]
+**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Admin Console Enhancements/Environment Warning.adoc[Environment Warning]
+**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Admin Console Enhancements/Asadmin Recorder.adoc[Asadmin Recorder]
+*** Security Configuration
+**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Security Configuration/Overview.adoc[Overview]
+**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Security Configuration/Multiple Mechanism in EAR.adoc[Multiple Mechanism in EAR]
+**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Security Configuration/JACC.adoc[JACC]
+**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Security Configuration/JCE Provider Support.adoc[JCE Provider Support]
+**** Client Certificates
+***** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Security Configuration/Client Certificates/Custom Validators.adoc[Custom Validators]
+***** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Security Configuration/Client Certificates/Advanced Groups Configuration.adoc[Advanced Groups Configuration]
+***** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Security Configuration/Client Certificates/Advanced Principal Name Configuration.adoc[Advanced Principal Name Configuration]
+*** Thread Pools
+**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Thread Pools/Default Thread Pool Size.adoc[Default Thread Pool Size]
+*** Classloading
+**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Classloading/Overview.adoc[Overview]
+**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Classloading/Standard Classloading.adoc[Standard Classloading]
+**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Classloading/Enhanced Classloading.adoc[Enhanced Classloading]
+*** Application Deployment
+**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Application Deployment/Overview.adoc[Overview]
+**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Application Deployment/Descriptor Elements.adoc[Descriptor Elements]
+**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Application Deployment/Deployment Descriptors.adoc[Deployment Descriptors]
+**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Application Deployment/Concurrent CDI Bean Loading.adoc[Concurrent CDI Bean Loading]
+*** Docker Host Support
+**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Docker Host Support/Docker Nodes.adoc[Docker Nodes]
+**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Docker Host Support/Docker Instances.adoc[Docker Instances]
+*** Configuration Options
+**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Configuration Options/Password Aliases.adoc[Password Aliases]
+**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Configuration Options/Phone Home.adoc[Phone Home]
+**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Configuration Options/JVM Options.adoc[JVM Options]
+**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Configuration Options/SSL Certificates.adoc[SSL Certificates]
+**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Configuration Options/System Properties.adoc[System Properties]
+**** Variable Substitution
+***** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Configuration Options/Variable Substitution/Usage of Variables.adoc[Usage of Variables]
+***** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Configuration Options/Variable Substitution/Types of Variables.adoc[Types of Variables]
+*** HTTP Service
+**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/HTTP Service/Overview.adoc[Overview]
+**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/HTTP Service/Protocols.adoc[Protocols]
+**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/HTTP Service/Virtual Servers.adoc[Virtual Servers]
+**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/HTTP Service/Network Listeners.adoc[Network Listeners]
+*** Asadmin Commands
+**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Asadmin Commands/Server Management Asadmin Commands.adoc[Server Management Asadmin Commands]
+**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Asadmin Commands/Multimode Event Designators Support.adoc[Multimode Event Designators Support]
+**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Asadmin Commands/Upgrade Payara.adoc[Upgrade Payara]
+**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Asadmin Commands/Auto Naming.adoc[Auto Naming]
+**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Asadmin Commands/Print Certificate Data.adoc[Print Certificate Data]
+*** Domain Data Grid And Hazelcast
+**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Domain Data Grid And Hazelcast/Overview.adoc[Overview]
+**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Domain Data Grid And Hazelcast/Datagrid in Applications.adoc[Datagrid in Applications]
+**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Domain Data Grid And Hazelcast/Configuration.adoc[Configuration]
+**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Domain Data Grid And Hazelcast/Encryption.adoc[Encryption]
+**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Domain Data Grid And Hazelcast/Viewing Members.adoc[Viewing Members]
+**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Domain Data Grid And Hazelcast/Discovery.adoc[Discovery]
+** Deployment Groups
+*** xref:Technical Documentation/Payara Server Documentation/Deployment Groups/Overview.adoc[Overview]
+*** xref:Technical Documentation/Payara Server Documentation/Deployment Groups/Asadmin Commands.adoc[Asadmin Commands]
+*** xref:Technical Documentation/Payara Server Documentation/Deployment Groups/Timers.adoc[Timers]
 ** Jakarta EE API
-*** xref:Technical Documentation/Payara Server Documentation/Jakarta EE API/JavaMail API.adoc[JavaMail API]
-*** xref:Technical Documentation/Payara Server Documentation/Jakarta EE API/JAX-WS Enhancements.adoc[JAX-WS Enhancements]
 *** xref:Technical Documentation/Payara Server Documentation/Jakarta EE API/JCache API.adoc[JCache API]
+*** xref:Technical Documentation/Payara Server Documentation/Jakarta EE API/JAX-WS Enhancements.adoc[JAX-WS Enhancements]
+*** xref:Technical Documentation/Payara Server Documentation/Jakarta EE API/JavaMail API.adoc[JavaMail API]
+*** JAX-RS
+**** xref:Technical Documentation/Payara Server Documentation/Jakarta EE API/JAX-RS/CDI With JAX-RS.adoc[CDI With JAX-RS]
 *** Enterprise Java Beans (EJB)
 **** xref:Technical Documentation/Payara Server Documentation/Jakarta EE API/Enterprise Java Beans (EJB)/Overview.adoc[Overview]
 **** xref:Technical Documentation/Payara Server Documentation/Jakarta EE API/Enterprise Java Beans (EJB)/Tracing Remote EJBs.adoc[Tracing Remote EJBs]
 **** xref:Technical Documentation/Payara Server Documentation/Jakarta EE API/Enterprise Java Beans (EJB)/JDK 17 Support.adoc[JDK 17 Support]
-*** JAX-RS
-**** xref:Technical Documentation/Payara Server Documentation/Jakarta EE API/JAX-RS/CDI With JAX-RS.adoc[CDI With JAX-RS]
-*** JBatch API
-**** xref:Technical Documentation/Payara Server Documentation/Jakarta EE API/JBatch API/Overview.adoc[Overview]
-**** xref:Technical Documentation/Payara Server Documentation/Jakarta EE API/JBatch API/Database Support.adoc[Database Support]
-**** xref:Technical Documentation/Payara Server Documentation/Jakarta EE API/JBatch API/Improved Asadmin CLI.adoc[Improved Asadmin CLI]
-**** xref:Technical Documentation/Payara Server Documentation/Jakarta EE API/JBatch API/Schema Name.adoc[Schema Name]
-**** xref:Technical Documentation/Payara Server Documentation/Jakarta EE API/JBatch API/Table Prefix and Suffix.adoc[Table Prefix and Suffix]
 *** JPA
 **** xref:Technical Documentation/Payara Server Documentation/Jakarta EE API/JPA/JPA Cache Coordination.adoc[JPA Cache Coordination]
 *** JSF API
 **** xref:Technical Documentation/Payara Server Documentation/Jakarta EE API/JSF API/JSF Options.adoc[JSF Options]
+*** JBatch API
+**** xref:Technical Documentation/Payara Server Documentation/Jakarta EE API/JBatch API/Overview.adoc[Overview]
+**** xref:Technical Documentation/Payara Server Documentation/Jakarta EE API/JBatch API/Schema Name.adoc[Schema Name]
+**** xref:Technical Documentation/Payara Server Documentation/Jakarta EE API/JBatch API/Table Prefix and Suffix.adoc[Table Prefix and Suffix]
+**** xref:Technical Documentation/Payara Server Documentation/Jakarta EE API/JBatch API/Database Support.adoc[Database Support]
+**** xref:Technical Documentation/Payara Server Documentation/Jakarta EE API/JBatch API/Improved Asadmin CLI.adoc[Improved Asadmin CLI]
 ** Logging and Monitoring
 *** xref:Technical Documentation/Payara Server Documentation/Logging and Monitoring/Logging.adoc[Logging]
-*** xref:Technical Documentation/Payara Server Documentation/Logging and Monitoring/HealthCheck Service.adoc[HealthCheck Service]
 *** xref:Technical Documentation/Payara Server Documentation/Logging and Monitoring/Monitoring Console.adoc[Monitoring Console]
-*** Monitoring Service
-**** xref:Technical Documentation/Payara Server Documentation/Logging and Monitoring/Monitoring Service/Basic Monitoring Configuration.adoc[Basic Monitoring Configuration]
-**** xref:Technical Documentation/Payara Server Documentation/Logging and Monitoring/Monitoring Service/JMX Monitoring.adoc[JMX Monitoring]
-**** xref:Technical Documentation/Payara Server Documentation/Logging and Monitoring/Monitoring Service/MBeans.adoc[MBeans]
-**** xref:Technical Documentation/Payara Server Documentation/Logging and Monitoring/Monitoring Service/Rest Monitoring.adoc[Rest Monitoring]
+*** xref:Technical Documentation/Payara Server Documentation/Logging and Monitoring/HealthCheck Service.adoc[HealthCheck Service]
+*** Request Tracing Service
+**** xref:Technical Documentation/Payara Server Documentation/Logging and Monitoring/Request Tracing Service/Overview.adoc[Overview]
+**** xref:Technical Documentation/Payara Server Documentation/Logging and Monitoring/Request Tracing Service/Terminology.adoc[Terminology]
+**** xref:Technical Documentation/Payara Server Documentation/Logging and Monitoring/Request Tracing Service/Configuration.adoc[Configuration]
+**** xref:Technical Documentation/Payara Server Documentation/Logging and Monitoring/Request Tracing Service/Asadmin Commands.adoc[Asadmin Commands]
+**** xref:Technical Documentation/Payara Server Documentation/Logging and Monitoring/Request Tracing Service/Usage.adoc[Usage]
 *** Notification Service
 **** xref:Technical Documentation/Payara Server Documentation/Logging and Monitoring/Notification Service/Overview.adoc[Overview]
 **** JMX Monitoring Notifications
 ***** xref:Technical Documentation/Payara Server Documentation/Logging and Monitoring/Notification Service/JMX Monitoring Notifications/JMX Monitoring Notifiers Asadmin Commands.adoc[JMX Monitoring Notifiers Asadmin Commands]
 ***** xref:Technical Documentation/Payara Server Documentation/Logging and Monitoring/Notification Service/JMX Monitoring Notifications/JMX Monitoring Notifiers Configuration.adoc[JMX Monitoring Notifiers Configuration]
-*** Request Tracing Service
-**** xref:Technical Documentation/Payara Server Documentation/Logging and Monitoring/Request Tracing Service/Overview.adoc[Overview]
-**** xref:Technical Documentation/Payara Server Documentation/Logging and Monitoring/Request Tracing Service/Asadmin Commands.adoc[Asadmin Commands]
-**** xref:Technical Documentation/Payara Server Documentation/Logging and Monitoring/Request Tracing Service/Configuration.adoc[Configuration]
-**** xref:Technical Documentation/Payara Server Documentation/Logging and Monitoring/Request Tracing Service/Terminology.adoc[Terminology]
-**** xref:Technical Documentation/Payara Server Documentation/Logging and Monitoring/Request Tracing Service/Usage.adoc[Usage]
+*** Monitoring Service
+**** xref:Technical Documentation/Payara Server Documentation/Logging and Monitoring/Monitoring Service/Rest Monitoring.adoc[Rest Monitoring]
+**** xref:Technical Documentation/Payara Server Documentation/Logging and Monitoring/Monitoring Service/MBeans.adoc[MBeans]
+**** xref:Technical Documentation/Payara Server Documentation/Logging and Monitoring/Monitoring Service/JMX Monitoring.adoc[JMX Monitoring]
+**** xref:Technical Documentation/Payara Server Documentation/Logging and Monitoring/Monitoring Service/Basic Monitoring Configuration.adoc[Basic Monitoring Configuration]
 ** Management and Monitoring REST API
-*** xref:Technical Documentation/Payara Server Documentation/Management and Monitoring REST API/Definitions.adoc[Definitions]
 *** xref:Technical Documentation/Payara Server Documentation/Management and Monitoring REST API/Rest API.adoc[Rest API]
-** Server Configuration And Management
-*** Admin Console Enhancements
-**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Admin Console Enhancements/Overview.adoc[Overview]
-**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Admin Console Enhancements/Asadmin Recorder.adoc[Asadmin Recorder]
-**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Admin Console Enhancements/Auditing Service.adoc[Auditing Service]
-**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Admin Console Enhancements/Environment Warning.adoc[Environment Warning]
-*** Application Deployment
-**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Application Deployment/Overview.adoc[Overview]
-**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Application Deployment/Concurrent CDI Bean Loading.adoc[Concurrent CDI Bean Loading]
-**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Application Deployment/Deployment Descriptors.adoc[Deployment Descriptors]
-**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Application Deployment/Descriptor Elements.adoc[Descriptor Elements]
-*** Asadmin Commands
-**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Asadmin Commands/Auto Naming.adoc[Auto Naming]
-**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Asadmin Commands/Multimode Event Designators Support.adoc[Multimode Event Designators Support]
-**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Asadmin Commands/Print Certificate Data.adoc[Print Certificate Data]
-**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Asadmin Commands/Server Management Asadmin Commands.adoc[Server Management Asadmin Commands]
-**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Asadmin Commands/Upgrade Payara.adoc[Upgrade Payara]
-*** Classloading
-**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Classloading/Overview.adoc[Overview]
-**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Classloading/Enhanced Classloading.adoc[Enhanced Classloading]
-**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Classloading/Standard Classloading.adoc[Standard Classloading]
-*** Configuration Options
-**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Configuration Options/JVM Options.adoc[JVM Options]
-**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Configuration Options/Password Aliases.adoc[Password Aliases]
-**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Configuration Options/Phone Home.adoc[Phone Home]
-**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Configuration Options/SSL Certificates.adoc[SSL Certificates]
-**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Configuration Options/System Properties.adoc[System Properties]
-**** Variable Substitution
-***** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Configuration Options/Variable Substitution/Types of Variables.adoc[Types of Variables]
-***** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Configuration Options/Variable Substitution/Usage of Variables.adoc[Usage of Variables]
-*** Docker Host Support
-**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Docker Host Support/Docker Instances.adoc[Docker Instances]
-**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Docker Host Support/Docker Nodes.adoc[Docker Nodes]
-*** Domain Data Grid And Hazelcast
-**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Domain Data Grid And Hazelcast/Overview.adoc[Overview]
-**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Domain Data Grid And Hazelcast/Configuration.adoc[Configuration]
-**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Domain Data Grid And Hazelcast/Datagrid in Applications.adoc[Datagrid in Applications]
-**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Domain Data Grid And Hazelcast/Discovery.adoc[Discovery]
-**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Domain Data Grid And Hazelcast/Encryption.adoc[Encryption]
-**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Domain Data Grid And Hazelcast/Viewing Members.adoc[Viewing Members]
-*** HTTP Service
-**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/HTTP Service/Overview.adoc[Overview]
-**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/HTTP Service/Network Listeners.adoc[Network Listeners]
-**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/HTTP Service/Protocols.adoc[Protocols]
-**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/HTTP Service/Virtual Servers.adoc[Virtual Servers]
-*** JDBC Resource Management
-**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/JDBC Resource Management/JDBC.adoc[JDBC]
-**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/JDBC Resource Management/SQL.adoc[SQL]
-*** Security Configuration
-**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Security Configuration/Overview.adoc[Overview]
-**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Security Configuration/JACC.adoc[JACC]
-**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Security Configuration/JCE Provider Support.adoc[JCE Provider Support]
-**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Security Configuration/Multiple Mechanism in EAR.adoc[Multiple Mechanism in EAR]
-**** Client Certificates
-***** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Security Configuration/Client Certificates/Advanced Groups Configuration.adoc[Advanced Groups Configuration]
-***** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Security Configuration/Client Certificates/Advanced Principal Name Configuration.adoc[Advanced Principal Name Configuration]
-***** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Security Configuration/Client Certificates/Custom Validators.adoc[Custom Validators]
-*** Thread Pools
-**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Thread Pools/Default Thread Pool Size.adoc[Default Thread Pool Size]
+*** xref:Technical Documentation/Payara Server Documentation/Management and Monitoring REST API/Definitions.adoc[Definitions]
+* Ecosystem
+** xref:Technical Documentation/Ecosystem/Overview.adoc[Overview]
+** Miscellaneous
+*** xref:Technical Documentation/Ecosystem/Miscellaneous/JAX-RS Extension.adoc[JAX-RS Extension]
+** Project Management Tools
+*** xref:Technical Documentation/Ecosystem/Project Management Tools/Gradle Plugin.adoc[Gradle Plugin]
+*** xref:Technical Documentation/Ecosystem/Project Management Tools/Maven Bom.adoc[Maven Bom]
+*** xref:Technical Documentation/Ecosystem/Project Management Tools/Maven Archetype.adoc[Maven Archetype]
+*** xref:Technical Documentation/Ecosystem/Project Management Tools/Maven Plugin.adoc[Maven Plugin]
+** Connector Suites
+*** xref:Technical Documentation/Ecosystem/Connector Suites/Security Connectors.adoc[Security Connectors]
+*** Cloud Connectors
+**** xref:Technical Documentation/Ecosystem/Connector Suites/Cloud Connectors/Overview.adoc[Overview]
+**** xref:Technical Documentation/Ecosystem/Connector Suites/Cloud Connectors/Amazon SQS.adoc[Amazon SQS]
+**** xref:Technical Documentation/Ecosystem/Connector Suites/Cloud Connectors/Azure SB.adoc[Azure SB]
+**** xref:Technical Documentation/Ecosystem/Connector Suites/Cloud Connectors/Apache Kafka.adoc[Apache Kafka]
+**** xref:Technical Documentation/Ecosystem/Connector Suites/Cloud Connectors/MQTT.adoc[MQTT]
+*** Arquillian Containers
+**** xref:Technical Documentation/Ecosystem/Connector Suites/Arquillian Containers/Overview.adoc[Overview]
+**** xref:Technical Documentation/Ecosystem/Connector Suites/Arquillian Containers/Payara Micro Managed.adoc[Payara Micro Managed]
+**** xref:Technical Documentation/Ecosystem/Connector Suites/Arquillian Containers/Payara Server Remote.adoc[Payara Server Remote]
+**** xref:Technical Documentation/Ecosystem/Connector Suites/Arquillian Containers/Payara Server Managed.adoc[Payara Server Managed]
+**** xref:Technical Documentation/Ecosystem/Connector Suites/Arquillian Containers/Payara Server Embedded.adoc[Payara Server Embedded]
+** IDE Integration
+*** Eclipse Plugin
+**** xref:Technical Documentation/Ecosystem/IDE Integration/Eclipse Plugin/Overview.adoc[Overview]
+**** xref:Technical Documentation/Ecosystem/IDE Integration/Eclipse Plugin/Payara Server.adoc[Payara Server]
+**** xref:Technical Documentation/Ecosystem/IDE Integration/Eclipse Plugin/Payara Micro.adoc[Payara Micro]
+*** NetBeans Plugin
+**** xref:Technical Documentation/Ecosystem/IDE Integration/NetBeans Plugin/Overview.adoc[Overview]
+**** xref:Technical Documentation/Ecosystem/IDE Integration/NetBeans Plugin/Payara Server.adoc[Payara Server]
+**** xref:Technical Documentation/Ecosystem/IDE Integration/NetBeans Plugin/Payara Micro.adoc[Payara Micro]
+*** VSCode Extension
+**** xref:Technical Documentation/Ecosystem/IDE Integration/VSCode Extension/Overview.adoc[Overview]
+**** xref:Technical Documentation/Ecosystem/IDE Integration/VSCode Extension/Payara Server.adoc[Payara Server]
+**** xref:Technical Documentation/Ecosystem/IDE Integration/VSCode Extension/Payara Micro.adoc[Payara Micro]
+*** Intellij Plugin
+**** xref:Technical Documentation/Ecosystem/IDE Integration/Intellij Plugin/Overview.adoc[Overview]
+**** xref:Technical Documentation/Ecosystem/IDE Integration/Intellij Plugin/Payara Server.adoc[Payara Server]
+**** xref:Technical Documentation/Ecosystem/IDE Integration/Intellij Plugin/Payara Micro.adoc[Payara Micro]
+* MicroProfile
+** xref:Technical Documentation/MicroProfile/Overview.adoc[Overview]
+** xref:Technical Documentation/MicroProfile/JWT.adoc[JWT]
+** xref:Technical Documentation/MicroProfile/Rest Client.adoc[Rest Client]
+** xref:Technical Documentation/MicroProfile/OpenAPI.adoc[OpenAPI]
+** xref:Technical Documentation/MicroProfile/Fault Tolerance.adoc[Fault Tolerance]
+** xref:Technical Documentation/MicroProfile/HealthCheck.adoc[HealthCheck]
+** xref:Technical Documentation/MicroProfile/Opentracing.adoc[Opentracing]
+** Metrics
+*** xref:Technical Documentation/MicroProfile/Metrics/Metrics Rest Endpoint.adoc[Metrics Rest Endpoint]
+*** xref:Technical Documentation/MicroProfile/Metrics/Vendor Metrics.adoc[Vendor Metrics]
+*** xref:Technical Documentation/MicroProfile/Metrics/Metrics Configuration.adoc[Metrics Configuration]
+** Config
+*** xref:Technical Documentation/MicroProfile/Config/Overview.adoc[Overview]
+*** xref:Technical Documentation/MicroProfile/Config/JDBC.adoc[JDBC]
+*** xref:Technical Documentation/MicroProfile/Config/LDAP.adoc[LDAP]
+*** xref:Technical Documentation/MicroProfile/Config/Directory.adoc[Directory]
+*** Cloud
+**** xref:Technical Documentation/MicroProfile/Config/Cloud/Overview.adoc[Overview]
+**** xref:Technical Documentation/MicroProfile/Config/Cloud/GCP.adoc[GCP]
+**** xref:Technical Documentation/MicroProfile/Config/Cloud/Hashicorp.adoc[Hashicorp]
+**** xref:Technical Documentation/MicroProfile/Config/Cloud/DynamoDB.adoc[DynamoDB]
+**** xref:Technical Documentation/MicroProfile/Config/Cloud/AWS.adoc[AWS]
+**** xref:Technical Documentation/MicroProfile/Config/Cloud/Azure.adoc[Azure]
 * Public API
 ** xref:Technical Documentation/Public API/Overview.adoc[Overview]
+** xref:Technical Documentation/Public API/Roles Permitted.adoc[Roles Permitted]
 ** xref:Technical Documentation/Public API/CDI Events.adoc[CDI Events]
-** xref:Technical Documentation/Public API/Clustered Singleton.adoc[Clustered Singleton]
 ** xref:Technical Documentation/Public API/OAuth Support.adoc[OAuth Support]
 ** xref:Technical Documentation/Public API/OpenID Connect Support.adoc[OpenID Connect Support]
-** xref:Technical Documentation/Public API/Roles Permitted.adoc[Roles Permitted]
 ** xref:Technical Documentation/Public API/Security Extensions.adoc[Security Extensions]
+** xref:Technical Documentation/Public API/Clustered Singleton.adoc[Clustered Singleton]
 
 include::partial$release-notes.adoc[Release Notes]
 
@@ -269,5 +270,5 @@ include::partial$eclipse-microprofile.adoc[Eclipse MicroProfile Certification]
 .Appendix
 * Schemas
 ** xref:Appendix/Schemas/Overview.adoc[Overview]
-** xref:Appendix/Schemas/payara-resources_1_6.dtd[payara-resources_1_6.dtd]
 ** xref:Appendix/Schemas/payara-web-app_4.dtd[payara-web-app_4.dtd]
+** xref:Appendix/Schemas/payara-resources_1_6.dtd[payara-resources_1_6.dtd]

--- a/community/docs/modules/ROOT/pages/Technical Documentation/Payara Micro Documentation/Payara Micro Docker Image.adoc
+++ b/community/docs/modules/ROOT/pages/Technical Documentation/Payara Micro Documentation/Payara Micro Docker Image.adoc
@@ -22,7 +22,7 @@ Keep in mind the following:
 [source, shell, subs=attributes+]
 .Using a specific version
 ----
-docker run -p 8080:8080 payara/micro:{currentVersion}
+docker run -p 8080:8080 payara/micro:{page-version}
 ----
 
 [[jdk-version]]
@@ -38,14 +38,14 @@ To switch from the default JDK 8 based image to the JDK 11 compatible one, just 
 
 [source, shell, subs=attributes+]
 ----
-docker run -p 8080:8080 payara/micro:{currentVersion}-jdk11
+docker run -p 8080:8080 payara/micro:{page-version}-jdk11
 ----
 
 To switch from the default JDK 8 based image to the JDK 17 compatible one, just add the corresponding suffix to the tag's name like this:
 
 [source, shell, subs=attributes+]
 ----
-docker run -p 8080:8080 payara/micro:{currentVersion}-jdk17
+docker run -p 8080:8080 payara/micro:{page-version}-jdk17
 ----
 
 [[ports]]

--- a/community/docs/modules/ROOT/pages/Technical Documentation/Payara Server Documentation/Extensions/Notifiers/Custom Notifiers.adoc
+++ b/community/docs/modules/ROOT/pages/Technical Documentation/Payara Server Documentation/Extensions/Notifiers/Custom Notifiers.adoc
@@ -170,7 +170,7 @@ The Notifier API itself is available in the `internal-api` artifact that is loca
 <dependency>
     <groupId>fish.payara.server.internal.common</groupId>
     <artifactId>internal-api</artifactId>
-    <version>{currentVersion}</version>
+    <version>{page-version}</version>
     <optional>true</optional>
 </dependency>
 ----

--- a/community/docs/modules/ROOT/pages/Technical Documentation/Payara Server Documentation/Payara Server Docker Image.adoc
+++ b/community/docs/modules/ROOT/pages/Technical Documentation/Payara Server Documentation/Payara Server Docker Image.adoc
@@ -22,7 +22,7 @@ Keep in mind the following:
 [source, shell, subs=attributes+]
 .Using a specific version
 ----
-docker run -p 8080:8080 payara/server-full:{currentVersion}
+docker run -p 8080:8080 payara/server-full:{page-version}
 ----
 
 [[other-distributions]]
@@ -43,14 +43,14 @@ To switch from the default JDK 8 based image to the JDK 11 compatible one, just 
 
 [source, shell, subs=attributes+]
 ----
-docker run -p 8080:8080 payara/server-full:{currentVersion}-jdk11
+docker run -p 8080:8080 payara/server-full:{page-version}-jdk11
 ----
 
 To switch from the default JDK 8 based image to the JDK 17 compatible one, just add the corresponding suffix to the tag's name like this:
 
 [source, shell, subs=attributes+]
 ----
-docker run -p 8080:8080 payara/server-full:{currentVersion}-jdk17
+docker run -p 8080:8080 payara/server-full:{page-version}-jdk17
 ----
 
 [[ports]]
@@ -102,7 +102,7 @@ The following sample command will launch a new Payara Server container and deplo
 
 [source, shell, subs=attributes+]
 ----
-docker run -p 8080:8080 -v ~/payara/apps:/opt/payara/deployments payara/server-full:{currentVersion}
+docker run -p 8080:8080 -v ~/payara/apps:/opt/payara/deployments payara/server-full:{page-version}
 ----
 
 [[deploy-using-custom-image]]

--- a/docs/modules/ROOT/pages/Technical Documentation/Ecosystem/Connector Suites/Arquillian Containers/Overview.adoc
+++ b/docs/modules/ROOT/pages/Technical Documentation/Ecosystem/Connector Suites/Arquillian Containers/Overview.adoc
@@ -3,7 +3,7 @@
 
 The Payara Arquillian containers provide various Arquillian containers for integration testing with Payara Community.
 
-In version {currentVersion}, the following containers are available:
+In version {page-version}, the following containers are available:
 
 Payara Server:
 

--- a/docs/modules/ROOT/pages/Technical Documentation/Ecosystem/Project Management Tools/Gradle Plugin.adoc
+++ b/docs/modules/ROOT/pages/Technical Documentation/Ecosystem/Project Management Tools/Gradle Plugin.adoc
@@ -22,7 +22,7 @@ plugins {
 [source, groovy, subs=attributes+]
 ----
 payaraMicro {
-    payaraVersion = '{currentVersion}'
+    payaraVersion = '{page-version}'
     deployWar = false
     useUberJar = true
     daemon = false
@@ -52,8 +52,8 @@ payaraMicro {
 |Absolute path to the java executable
 
 |`payaraVersion`
-|{currentVersion}
-|By default `microBundle` task fetches payara-micro with version {currentVersion}
+|{page-version}
+|By default `microBundle` task fetches payara-micro with version {page-version}
 |=== 
 
 [[start]]
@@ -78,8 +78,8 @@ payaraMicro {
 |Absolute path to payara-micro executable.
 
 |`payaraVersion`
-|{currentVersion}
-|By default `microStart` task fetches Payara Micro with version {currentVersion}.
+|{page-version}
+|By default `microStart` task fetches Payara Micro with version {page-version}.
 
 |`daemon`
 |false

--- a/docs/modules/ROOT/pages/Technical Documentation/Ecosystem/Project Management Tools/Maven Bom.adoc
+++ b/docs/modules/ROOT/pages/Technical Documentation/Ecosystem/Project Management Tools/Maven Bom.adoc
@@ -22,7 +22,7 @@ Add following snippet to your Maven project:
         <dependency>
             <groupId>fish.payara.api</groupId>
             <artifactId>payara-bom</artifactId>
-            <version>{currentVersion}</version>
+            <version>{page-version}</version>
             <type>pom</type>
             <scope>import</scope>
         </dependency>

--- a/docs/modules/ROOT/pages/Technical Documentation/Ecosystem/Project Management Tools/Maven Plugin.adoc
+++ b/docs/modules/ROOT/pages/Technical Documentation/Ecosystem/Project Management Tools/Maven Plugin.adoc
@@ -75,8 +75,8 @@ Example:
 |Appends all system properties defined into the `payara-boot.properties` file.
 
 |`payaraVersion`
-|{currentVersion}
-|By default bundle mojo fetches Payara Micro with version {currentVersion}.
+|{page-version}
+|By default bundle mojo fetches Payara Micro with version {page-version}.
 
 |`deployArtifacts`
 |_None_
@@ -128,11 +128,11 @@ Example:
     <configuration>
         <useUberJar>true</useUberJar>
         <payaraMicroAbsolutePath>/path/to/payara-micro.jar</payaraMicroAbsolutePath>
-        <payaraVersion>{currentVersion}</payaraVersion>
+        <payaraVersion>{page-version}</payaraVersion>
         <artifactItem>
             <groupId>fish.payara.extras</groupId>
             <artifactId>payara-micro</artifactId>
-            <version>{currentVersion}</version>
+            <version>{page-version}</version>
         </artifactItem>
         <daemon>true</daemon>
         <javaPath>/path/to/Java/Executable</javaPath>
@@ -183,8 +183,8 @@ NOTE: If you want to execute the payara-micro plugin along with maven-toolchains
 |Absolute path to the Payara Micro executable.
 
 |`payaraVersion`
-|{currentVersion}
-|By default start mojo fetches payara-micro with version {currentVersion}.
+|{page-version}
+|By default start mojo fetches payara-micro with version {page-version}.
 
 |`artifactItem`
 |_none_
@@ -248,7 +248,7 @@ Example:
         <artifactItem>
             <groupId>fish.payara.extras</groupId>
             <artifactId>payara-micro</artifactId>
-            <version>{currentVersion}</version>
+            <version>{page-version}</version>
         </artifactItem>
     </configuration>
 </plugin>

--- a/docs/modules/ROOT/pages/Technical Documentation/Payara Micro Documentation/Maven Support.adoc
+++ b/docs/modules/ROOT/pages/Technical Documentation/Payara Micro Documentation/Maven Support.adoc
@@ -15,7 +15,7 @@ To do this, use the following GAV coordinates:
 <dependency>
     <groupId>fish.payara.extras</groupId>
     <artifactId>payara-micro</artifactId>
-    <version>{currentVersion}</version>
+    <version>{page-version}</version>
 </dependency>
 ----
 

--- a/docs/modules/ROOT/pages/Technical Documentation/Payara Server Documentation/Jakarta EE API/Enterprise Java Beans (EJB)/Overview.adoc
+++ b/docs/modules/ROOT/pages/Technical Documentation/Payara Server Documentation/Jakarta EE API/Enterprise Java Beans (EJB)/Overview.adoc
@@ -300,7 +300,7 @@ Client applications that wish to use HTTP(S) as the transport protocol when call
 <dependency>
     <groupId>fish.payara.extras</groupId>
     <artifactId>ejb-http-client</artifactId>
-    <version>{currentVersion}</version>
+    <version>{page-version}</version>
 </dependency>
 ----
 

--- a/docs/modules/ROOT/pages/Technical Documentation/Payara Server Documentation/Logging and Monitoring/Request Tracing Service/Overview.adoc
+++ b/docs/modules/ROOT/pages/Technical Documentation/Payara Server Documentation/Logging and Monitoring/Request Tracing Service/Overview.adoc
@@ -45,7 +45,7 @@ NOTE: The new MicroProfile `@Traced` annotation replaces the Payara Server & Mic
 |===
 |Payara Server & Micro Version
 |OpenTracing.io API Version
-| 4.1.2.183 - 4.1.2.191; 5.183 - {currentVersion}
+| 4.1.2.183 - 4.1.2.191; 5.183 - {page-version}
 | 0.31
 | 4.1.2.182; 5.182
 | 0.30

--- a/docs/modules/ROOT/pages/Technical Documentation/Payara Server Documentation/Overview.adoc
+++ b/docs/modules/ROOT/pages/Technical Documentation/Payara Server Documentation/Overview.adoc
@@ -4,7 +4,7 @@
 
 Documentation of Payara Server features. Includes full documentation of the features added on top of _GlassFish Server {glassfishVersion} Open Source Edition_ as well as features shared with GlassFish Server or their improvements specific to Payara Server.
 
-All documentation for _GlassFish Server {glassfishVersion}_ is also valid for Payara Server {currentVersion} unless stated otherwise in Payara Server documentation.
+All documentation for _GlassFish Server {glassfishVersion}_ is also valid for Payara Server {page-version} unless stated otherwise in Payara Server documentation.
 
 [[docker-images]]
 == Docker Images

--- a/docs/modules/ROOT/pages/Technical Documentation/Payara Server Documentation/Server Configuration And Management/Configuration Options/Phone Home.adoc
+++ b/docs/modules/ROOT/pages/Technical Documentation/Payara Server Documentation/Server Configuration And Management/Configuration Options/Phone Home.adoc
@@ -10,7 +10,7 @@ The following is the list of information attributes gathered by the Phone Home s
 [cols=",",options="header",]
 |=======================================================================
 |Attribute |Example
-|Payara Server Version |{currentVersion} #badassfish
+|Payara Server Version |{page-version} #badassfish
 |Java Virtual Machine Version |1.8.0_121
 |Domain Uptime |36500
 |Number of nodes in the domain |1

--- a/docs/modules/ROOT/pages/Technical Documentation/Payara Server Documentation/Server Configuration And Management/Docker Host Support/Docker Nodes.adoc
+++ b/docs/modules/ROOT/pages/Technical Documentation/Payara Server Documentation/Server Configuration And Management/Docker Host Support/Docker Nodes.adoc
@@ -28,7 +28,7 @@ Docker nodes do have some unique configuration properties however:
 * Docker Password File - This is the fully-qualified path of the password file that the Docker instance will use for authentication against the DAS. Please note, that this path should be the path to the file on the *remote* machine. This file should be a standard Payara password file as you would use with asadmin. This must be specified, as Docker instances require secure admin to be enabled to start.
 * TLS - Whether or not to use HTTPS to communicate with the Docker engine or not.
 * Docker Port - The port that the Docker engine is listening on. Defaults to 2376.
-* Docker Image - The Docker image to use. Payara Server will default to using the `payara/payaraserver-node:{currentVersion}` image.
+* Docker Image - The Docker image to use. Payara Server will default to using the `payara/payaraserver-node:{page-version}` image.
 
 The configuration options of CONFIG nodes are also available, namely `nodehost`, `nodedir`, and `installdir`. Specifying the `nodehost` option remains mandatory, but for docker nodes the `installdir` and `nodedir` options can safely be left as their defaults unless you're specifying your own Docker image.
 

--- a/docs/modules/ROOT/pages/Technical Documentation/Payara Server Documentation/Server Configuration And Management/Domain Data Grid And Hazelcast/Datagrid in Applications.adoc
+++ b/docs/modules/ROOT/pages/Technical Documentation/Payara Server Documentation/Server Configuration And Management/Domain Data Grid And Hazelcast/Datagrid in Applications.adoc
@@ -22,7 +22,7 @@ To import the Hazelcast package, you will need to set add the Public API artefac
 <dependency>
   <groupId>fish.payara.api</groupId>
   <artifactId>payara-api</artifactId>
-  <version>${currentVersion}</version>
+  <version>${page-version}</version>
 </dependency>
 ----
 

--- a/docs/modules/ROOT/pages/Technical Documentation/Payara Server Documentation/Server Configuration And Management/Security Configuration/Client Certificates/Custom Validators.adoc
+++ b/docs/modules/ROOT/pages/Technical Documentation/Payara Server Documentation/Server Configuration And Management/Security Configuration/Client Certificates/Custom Validators.adoc
@@ -19,7 +19,7 @@ To have the `ClientCertificateValidator` interface available in your application
 <dependency>
     <groupId>fish.payara.api</groupId>
     <artifactId>payara-api</artifactId>
-    <version>{currentVersion}</version>
+    <version>{page-version}</version>
     <scope>provided</scope>
 </dependency>
 ----

--- a/enterprise/docs/antora.yml
+++ b/enterprise/docs/antora.yml
@@ -6,7 +6,6 @@ nav:
   - modules/ROOT/nav.adoc
 asciidoc:
   attributes:
-    currentVersion: '5.36.0'
     glassfishVersion: '5'
     payaraWebDtd: 'https://raw.githubusercontent.com/payara/Payara-Enterprise-Documentation/master/docs/modules/ROOT/pages/schemas/payara-web-app_4.dtd'
     payaraResourcesDtd: 'https://raw.githubusercontent.com/payara/Payara-Enterprise-Documentation/master/docs/modules/ROOT/pages/schemas/payara-resources_1_6.dtd'

--- a/enterprise/docs/modules/ROOT/nav.adoc
+++ b/enterprise/docs/modules/ROOT/nav.adoc
@@ -5,255 +5,255 @@
 * xref:General Info/Supported Platforms.adoc[Supported Platforms]
 
 .Technical Documentation
-* Ecosystem
-** xref:Technical Documentation/Ecosystem/Overview.adoc[Overview]
-** Connector Suites
-*** xref:Technical Documentation/Ecosystem/Connector Suites/Security Connectors.adoc[Security Connectors]
-*** Arquillian Containers
-**** xref:Technical Documentation/Ecosystem/Connector Suites/Arquillian Containers/Overview.adoc[Overview]
-**** xref:Technical Documentation/Ecosystem/Connector Suites/Arquillian Containers/Payara Micro Managed.adoc[Payara Micro Managed]
-**** xref:Technical Documentation/Ecosystem/Connector Suites/Arquillian Containers/Payara Server Embedded.adoc[Payara Server Embedded]
-**** xref:Technical Documentation/Ecosystem/Connector Suites/Arquillian Containers/Payara Server Managed.adoc[Payara Server Managed]
-**** xref:Technical Documentation/Ecosystem/Connector Suites/Arquillian Containers/Payara Server Remote.adoc[Payara Server Remote]
-*** Cloud Connectors
-**** xref:Technical Documentation/Ecosystem/Connector Suites/Cloud Connectors/Overview.adoc[Overview]
-**** xref:Technical Documentation/Ecosystem/Connector Suites/Cloud Connectors/Amazon SQS.adoc[Amazon SQS]
-**** xref:Technical Documentation/Ecosystem/Connector Suites/Cloud Connectors/Apache Kafka.adoc[Apache Kafka]
-**** xref:Technical Documentation/Ecosystem/Connector Suites/Cloud Connectors/Azure SB.adoc[Azure SB]
-**** xref:Technical Documentation/Ecosystem/Connector Suites/Cloud Connectors/MQTT.adoc[MQTT]
-** IDE Integration
-*** Eclipse Plugin
-**** xref:Technical Documentation/Ecosystem/IDE Integration/Eclipse Plugin/Overview.adoc[Overview]
-**** xref:Technical Documentation/Ecosystem/IDE Integration/Eclipse Plugin/Payara Micro.adoc[Payara Micro]
-**** xref:Technical Documentation/Ecosystem/IDE Integration/Eclipse Plugin/Payara Server.adoc[Payara Server]
-*** Intellij Plugin
-**** xref:Technical Documentation/Ecosystem/IDE Integration/Intellij Plugin/Overview.adoc[Overview]
-**** xref:Technical Documentation/Ecosystem/IDE Integration/Intellij Plugin/Payara Micro.adoc[Payara Micro]
-**** xref:Technical Documentation/Ecosystem/IDE Integration/Intellij Plugin/Payara Server.adoc[Payara Server]
-*** NetBeans Plugin
-**** xref:Technical Documentation/Ecosystem/IDE Integration/NetBeans Plugin/Overview.adoc[Overview]
-**** xref:Technical Documentation/Ecosystem/IDE Integration/NetBeans Plugin/Payara Micro.adoc[Payara Micro]
-**** xref:Technical Documentation/Ecosystem/IDE Integration/NetBeans Plugin/Payara Server.adoc[Payara Server]
-*** VSCode Extension
-**** xref:Technical Documentation/Ecosystem/IDE Integration/VSCode Extension/Overview.adoc[Overview]
-**** xref:Technical Documentation/Ecosystem/IDE Integration/VSCode Extension/Payara Micro.adoc[Payara Micro]
-**** xref:Technical Documentation/Ecosystem/IDE Integration/VSCode Extension/Payara Server.adoc[Payara Server]
-** Miscellaneous
-*** xref:Technical Documentation/Ecosystem/Miscellaneous/JAX-RS Extension.adoc[JAX-RS Extension]
-** Project Management Tools
-*** xref:Technical Documentation/Ecosystem/Project Management Tools/Gradle Plugin.adoc[Gradle Plugin]
-*** xref:Technical Documentation/Ecosystem/Project Management Tools/Maven Archetype.adoc[Maven Archetype]
-*** xref:Technical Documentation/Ecosystem/Project Management Tools/Maven Bom.adoc[Maven Bom]
-*** xref:Technical Documentation/Ecosystem/Project Management Tools/Maven Plugin.adoc[Maven Plugin]
-* MicroProfile
-** xref:Technical Documentation/MicroProfile/Overview.adoc[Overview]
-** xref:Technical Documentation/MicroProfile/JWT.adoc[JWT]
-** xref:Technical Documentation/MicroProfile/Rest Client.adoc[Rest Client]
-** xref:Technical Documentation/MicroProfile/Fault Tolerance.adoc[Fault Tolerance]
-** xref:Technical Documentation/MicroProfile/HealthCheck.adoc[HealthCheck]
-** xref:Technical Documentation/MicroProfile/OpenAPI.adoc[OpenAPI]
-** xref:Technical Documentation/MicroProfile/Opentracing.adoc[Opentracing]
-** Config
-*** xref:Technical Documentation/MicroProfile/Config/Overview.adoc[Overview]
-*** xref:Technical Documentation/MicroProfile/Config/Directory.adoc[Directory]
-*** xref:Technical Documentation/MicroProfile/Config/JDBC.adoc[JDBC]
-*** xref:Technical Documentation/MicroProfile/Config/LDAP.adoc[LDAP]
-*** Cloud
-**** xref:Technical Documentation/MicroProfile/Config/Cloud/Overview.adoc[Overview]
-**** xref:Technical Documentation/MicroProfile/Config/Cloud/AWS.adoc[AWS]
-**** xref:Technical Documentation/MicroProfile/Config/Cloud/DynamoDB.adoc[DynamoDB]
-**** xref:Technical Documentation/MicroProfile/Config/Cloud/GCP.adoc[GCP]
-**** xref:Technical Documentation/MicroProfile/Config/Cloud/Hashicorp.adoc[Hashicorp]
-**** xref:Technical Documentation/MicroProfile/Config/Cloud/Azure.adoc[Azure]
-** Metrics
-*** xref:Technical Documentation/MicroProfile/Metrics/Metrics Configuration.adoc[Metrics Configuration]
-*** xref:Technical Documentation/MicroProfile/Metrics/Metrics Rest Endpoint.adoc[Metrics Rest Endpoint]
-*** xref:Technical Documentation/MicroProfile/Metrics/Vendor Metrics.adoc[Vendor Metrics]
 * Payara Micro Documentation
 ** xref:Technical Documentation/Payara Micro Documentation/Overview.adoc[Overview]
 ** xref:Technical Documentation/Payara Micro Documentation/Maven Support.adoc[Maven Support]
 ** xref:Technical Documentation/Payara Micro Documentation/Payara Micro Docker Image.adoc[Payara Micro Docker Image]
-** API
-*** xref:Technical Documentation/Payara Micro Documentation/API/JCache in Payara Micro.adoc[JCache in Payara Micro]
-*** Payara Micro API
-**** xref:Technical Documentation/Payara Micro Documentation/API/Payara Micro API/Overview.adoc[Overview]
-**** xref:Technical Documentation/Payara Micro Documentation/API/Payara Micro API/Using the Payara Micro API.adoc[Using the Payara Micro API]
 ** Extensions
-*** xref:Technical Documentation/Payara Micro Documentation/Extensions/JCA Support.adoc[JCA Support]
 *** xref:Technical Documentation/Payara Micro Documentation/Extensions/Persistent EJB Timers.adoc[Persistent EJB Timers]
 *** xref:Technical Documentation/Payara Micro Documentation/Extensions/Remote CDI Events.adoc[Remote CDI Events]
 *** xref:Technical Documentation/Payara Micro Documentation/Extensions/Running Callable Objects.adoc[Running Callable Objects]
+*** xref:Technical Documentation/Payara Micro Documentation/Extensions/JCA Support.adoc[JCA Support]
+** Payara Micro Configuration and Management
+*** Micro Management
+**** xref:Technical Documentation/Payara Micro Documentation/Payara Micro Configuration and Management/Micro Management/Configuring An Instance.adoc[Configuring An Instance]
+**** xref:Technical Documentation/Payara Micro Documentation/Payara Micro Configuration and Management/Micro Management/Clustering.adoc[Clustering]
+**** xref:Technical Documentation/Payara Micro Documentation/Payara Micro Configuration and Management/Micro Management/HTTP(S) Auto-Binding.adoc[HTTP(S) Auto-Binding]
+**** Jar Structure and Configuration
+***** xref:Technical Documentation/Payara Micro Documentation/Payara Micro Configuration and Management/Micro Management/Jar Structure and Configuration/Payara Micro Jar Structure.adoc[Payara Micro Jar Structure]
+***** xref:Technical Documentation/Payara Micro Documentation/Payara Micro Configuration and Management/Micro Management/Jar Structure and Configuration/Root Directory.adoc[Root Directory]
+***** xref:Technical Documentation/Payara Micro Documentation/Payara Micro Configuration and Management/Micro Management/Jar Structure and Configuration/Adding Jars.adoc[Adding Jars]
+**** Stopping and Starting Instances
+***** xref:Technical Documentation/Payara Micro Documentation/Payara Micro Configuration and Management/Micro Management/Stopping and Starting Instances/Stopping Instance.adoc[Stopping Instance]
+***** xref:Technical Documentation/Payara Micro Documentation/Payara Micro Configuration and Management/Micro Management/Stopping and Starting Instances/Starting Instance.adoc[Starting Instance]
+**** Deploying Applications
+***** xref:Technical Documentation/Payara Micro Documentation/Payara Micro Configuration and Management/Micro Management/Deploying Applications/Deploy Applications Programmatically.adoc[Deploy Applications Programmatically]
+***** xref:Technical Documentation/Payara Micro Documentation/Payara Micro Configuration and Management/Micro Management/Deploying Applications/Deploy Applications.adoc[Deploy Applications]
+**** Command Line Options
+***** xref:Technical Documentation/Payara Micro Documentation/Payara Micro Configuration and Management/Micro Management/Command Line Options/Disable Phone Home.adoc[Disable Phone Home]
+***** xref:Technical Documentation/Payara Micro Documentation/Payara Micro Configuration and Management/Micro Management/Command Line Options/Command Line Options.adoc[Command Line Options]
+**** Asadmin Commands
+***** xref:Technical Documentation/Payara Micro Documentation/Payara Micro Configuration and Management/Micro Management/Asadmin Commands/Send Asadmin Commands from Admin Console.adoc[Send Asadmin Commands from Admin Console]
+***** xref:Technical Documentation/Payara Micro Documentation/Payara Micro Configuration and Management/Micro Management/Asadmin Commands/Pre and Post Boot Commands.adoc[Pre and Post Boot Commands]
+*** Database Management
+**** xref:Technical Documentation/Payara Micro Documentation/Payara Micro Configuration and Management/Database Management/Slow SQL Logger.adoc[Slow SQL Logger]
+**** xref:Technical Documentation/Payara Micro Documentation/Payara Micro Configuration and Management/Database Management/Log JDBC Calls.adoc[Log JDBC Calls]
+**** xref:Technical Documentation/Payara Micro Documentation/Payara Micro Configuration and Management/Database Management/SQL Trace Listeners.adoc[SQL Trace Listeners]
 ** Logging and Monitoring
 *** xref:Technical Documentation/Payara Micro Documentation/Logging and Monitoring/Request Tracing.adoc[Request Tracing]
 *** Logging
 **** xref:Technical Documentation/Payara Micro Documentation/Logging and Monitoring/Logging/Config Access Log.adoc[Config Access Log]
 **** xref:Technical Documentation/Payara Micro Documentation/Logging and Monitoring/Logging/Logging to File.adoc[Logging to File]
-** Payara Micro Configuration and Management
-*** Database Management
-**** xref:Technical Documentation/Payara Micro Documentation/Payara Micro Configuration and Management/Database Management/Log JDBC Calls.adoc[Log JDBC Calls]
-**** xref:Technical Documentation/Payara Micro Documentation/Payara Micro Configuration and Management/Database Management/Slow SQL Logger.adoc[Slow SQL Logger]
-**** xref:Technical Documentation/Payara Micro Documentation/Payara Micro Configuration and Management/Database Management/SQL Trace Listeners.adoc[SQL Trace Listeners]
-*** Micro Management
-**** xref:Technical Documentation/Payara Micro Documentation/Payara Micro Configuration and Management/Micro Management/Clustering.adoc[Clustering]
-**** xref:Technical Documentation/Payara Micro Documentation/Payara Micro Configuration and Management/Micro Management/Configuring An Instance.adoc[Configuring An Instance]
-**** xref:Technical Documentation/Payara Micro Documentation/Payara Micro Configuration and Management/Micro Management/HTTP(S) Auto-Binding.adoc[HTTP(S) Auto-Binding]
-**** Asadmin Commands
-***** xref:Technical Documentation/Payara Micro Documentation/Payara Micro Configuration and Management/Micro Management/Asadmin Commands/Pre and Post Boot Commands.adoc[Pre and Post Boot Commands]
-***** xref:Technical Documentation/Payara Micro Documentation/Payara Micro Configuration and Management/Micro Management/Asadmin Commands/Send Asadmin Commands from Admin Console.adoc[Send Asadmin Commands from Admin Console]
-**** Command Line Options
-***** xref:Technical Documentation/Payara Micro Documentation/Payara Micro Configuration and Management/Micro Management/Command Line Options/Command Line Options.adoc[Command Line Options]
-***** xref:Technical Documentation/Payara Micro Documentation/Payara Micro Configuration and Management/Micro Management/Command Line Options/Disable Phone Home.adoc[Disable Phone Home]
-**** Deploying Applications
-***** xref:Technical Documentation/Payara Micro Documentation/Payara Micro Configuration and Management/Micro Management/Deploying Applications/Deploy Applications Programmatically.adoc[Deploy Applications Programmatically]
-***** xref:Technical Documentation/Payara Micro Documentation/Payara Micro Configuration and Management/Micro Management/Deploying Applications/Deploy Applications.adoc[Deploy Applications]
-**** Jar Structure and Configuration
-***** xref:Technical Documentation/Payara Micro Documentation/Payara Micro Configuration and Management/Micro Management/Jar Structure and Configuration/Adding Jars.adoc[Adding Jars]
-***** xref:Technical Documentation/Payara Micro Documentation/Payara Micro Configuration and Management/Micro Management/Jar Structure and Configuration/Payara Micro Jar Structure.adoc[Payara Micro Jar Structure]
-***** xref:Technical Documentation/Payara Micro Documentation/Payara Micro Configuration and Management/Micro Management/Jar Structure and Configuration/Root Directory.adoc[Root Directory]
-**** Stopping and Starting Instances
-***** xref:Technical Documentation/Payara Micro Documentation/Payara Micro Configuration and Management/Micro Management/Stopping and Starting Instances/Starting Instance.adoc[Starting Instance]
-***** xref:Technical Documentation/Payara Micro Documentation/Payara Micro Configuration and Management/Micro Management/Stopping and Starting Instances/Stopping Instance.adoc[Stopping Instance]
+** API
+*** xref:Technical Documentation/Payara Micro Documentation/API/JCache in Payara Micro.adoc[JCache in Payara Micro]
+*** Payara Micro API
+**** xref:Technical Documentation/Payara Micro Documentation/API/Payara Micro API/Overview.adoc[Overview]
+**** xref:Technical Documentation/Payara Micro Documentation/API/Payara Micro API/Using the Payara Micro API.adoc[Using the Payara Micro API]
 * Payara Server Documentation
 ** xref:Technical Documentation/Payara Server Documentation/Overview.adoc[Overview]
 ** xref:Technical Documentation/Payara Server Documentation/Payara Server Docker Image.adoc[Payara Server Docker Image]
 ** Upgrade Tool
 *** xref:Technical Documentation/Payara Server Documentation/Upgrade Tool/Overview.adoc[Overview]
-** Deployment Groups
-*** xref:Technical Documentation/Payara Server Documentation/Deployment Groups/Overview.adoc[Overview]
-*** xref:Technical Documentation/Payara Server Documentation/Deployment Groups/Asadmin Commands.adoc[Asadmin Commands]
-*** xref:Technical Documentation/Payara Server Documentation/Deployment Groups/Timers.adoc[Timers]
-** Development Debugging And Assistance Tools
-*** xref:Technical Documentation/Payara Server Documentation/Development Debugging And Assistance Tools/CDI.adoc[CDI]
 ** Extensions
 *** xref:Technical Documentation/Payara Server Documentation/Extensions/Overview.adoc[Overview]
 *** gRPC Support
 **** xref:Technical Documentation/Payara Server Documentation/Extensions/gRPC Support/Overview.adoc[Overview]
 **** xref:Technical Documentation/Payara Server Documentation/Extensions/gRPC Support/Usage.adoc[Usage]
 **** xref:Technical Documentation/Payara Server Documentation/Extensions/gRPC Support/Installation.adoc[Installation]
-** Jakarta EE API
-*** xref:Technical Documentation/Payara Server Documentation/Jakarta EE API/JavaMail API.adoc[JavaMail API]
-*** xref:Technical Documentation/Payara Server Documentation/Jakarta EE API/JAX-WS Enhancements.adoc[JAX-WS Enhancements]
-*** xref:Technical Documentation/Payara Server Documentation/Jakarta EE API/JCache API.adoc[JCache API]
-*** Enterprise Java Beans (EJB)
-**** xref:Technical Documentation/Payara Server Documentation/Jakarta EE API/Enterprise Java Beans (EJB)/Overview.adoc[Overview]
-**** xref:Technical Documentation/Payara Server Documentation/Jakarta EE API/Enterprise Java Beans (EJB)/Tracing Remote EJBs.adoc[Tracing Remote EJBs]
-*** JAX-RS
-**** xref:Technical Documentation/Payara Server Documentation/Jakarta EE API/JAX-RS/CDI With JAX-RS.adoc[CDI With JAX-RS]
-*** JBatch API
-**** xref:Technical Documentation/Payara Server Documentation/Jakarta EE API/JBatch API/Overview.adoc[Overview]
-**** xref:Technical Documentation/Payara Server Documentation/Jakarta EE API/JBatch API/Database Support.adoc[Database Support]
-**** xref:Technical Documentation/Payara Server Documentation/Jakarta EE API/JBatch API/Improved Asadmin CLI.adoc[Improved Asadmin CLI]
-**** xref:Technical Documentation/Payara Server Documentation/Jakarta EE API/JBatch API/Schema Name.adoc[Schema Name]
-**** xref:Technical Documentation/Payara Server Documentation/Jakarta EE API/JBatch API/Table Prefix and Suffix.adoc[Table Prefix and Suffix]
-*** JPA
-**** xref:Technical Documentation/Payara Server Documentation/Jakarta EE API/JPA/JPA Cache Coordination.adoc[JPA Cache Coordination]
-*** JSF API
-**** xref:Technical Documentation/Payara Server Documentation/Jakarta EE API/JSF API/JSF Options.adoc[JSF Options]
-** Logging and Monitoring
-*** xref:Technical Documentation/Payara Server Documentation/Logging and Monitoring/Logging.adoc[Logging]
-*** xref:Technical Documentation/Payara Server Documentation/Logging and Monitoring/HealthCheck Service.adoc[HealthCheck Service]
-*** xref:Technical Documentation/Payara Server Documentation/Logging and Monitoring/Payara InSight.adoc[Payara InSight]
-*** Monitoring Service
-**** xref:Technical Documentation/Payara Server Documentation/Logging and Monitoring/Monitoring Service/Basic Monitoring Configuration.adoc[Basic Monitoring Configuration]
-**** xref:Technical Documentation/Payara Server Documentation/Logging and Monitoring/Monitoring Service/JMX Monitoring.adoc[JMX Monitoring]
-**** xref:Technical Documentation/Payara Server Documentation/Logging and Monitoring/Monitoring Service/MBeans.adoc[MBeans]
-**** xref:Technical Documentation/Payara Server Documentation/Logging and Monitoring/Monitoring Service/Rest Monitoring.adoc[Rest Monitoring]
-*** Notification Service
-**** xref:Technical Documentation/Payara Server Documentation/Logging and Monitoring/Notification Service/Overview.adoc[Overview]
-**** Notifiers
-***** xref:Technical Documentation/Payara Server Documentation/Logging and Monitoring/Notification Service/Notifiers/CDI Event Bus Notifier.adoc[CDI Event Bus Notifier]
-***** xref:Technical Documentation/Payara Server Documentation/Logging and Monitoring/Notification Service/Notifiers/Custom Notifier.adoc[Custom Notifier]
-***** xref:Technical Documentation/Payara Server Documentation/Logging and Monitoring/Notification Service/Notifiers/Datadog Notifier.adoc[Datadog Notifier]
-***** xref:Technical Documentation/Payara Server Documentation/Logging and Monitoring/Notification Service/Notifiers/Discord Notifier.adoc[Discord Notifier]
-***** xref:Technical Documentation/Payara Server Documentation/Logging and Monitoring/Notification Service/Notifiers/Email Notifier.adoc[Email Notifier]
-***** xref:Technical Documentation/Payara Server Documentation/Logging and Monitoring/Notification Service/Notifiers/Event Bus Notifier.adoc[Event Bus Notifier]
-***** xref:Technical Documentation/Payara Server Documentation/Logging and Monitoring/Notification Service/Notifiers/JMS Notifier.adoc[JMS Notifier]
-***** xref:Technical Documentation/Payara Server Documentation/Logging and Monitoring/Notification Service/Notifiers/Log Notifier.adoc[Log Notifier]
-***** xref:Technical Documentation/Payara Server Documentation/Logging and Monitoring/Notification Service/Notifiers/New Relic Notifier.adoc[New Relic Notifier]
-***** xref:Technical Documentation/Payara Server Documentation/Logging and Monitoring/Notification Service/Notifiers/Slack Notifier.adoc[Slack Notifier]
-***** xref:Technical Documentation/Payara Server Documentation/Logging and Monitoring/Notification Service/Notifiers/SNMP Notifier.adoc[SNMP Notifier]
-***** xref:Technical Documentation/Payara Server Documentation/Logging and Monitoring/Notification Service/Notifiers/Teams Notifier.adoc[Teams Notifier]
-***** xref:Technical Documentation/Payara Server Documentation/Logging and Monitoring/Notification Service/Notifiers/XMPP Notifier.adoc[XMPP Notifier]
-**** JMX Monitoring Notifications
-***** xref:Technical Documentation/Payara Server Documentation/Logging and Monitoring/Notification Service/JMX Monitoring Notifications/JMX Monitoring Notifiers Asadmin Commands.adoc[JMX Monitoring Notifiers Asadmin Commands]
-***** xref:Technical Documentation/Payara Server Documentation/Logging and Monitoring/Notification Service/JMX Monitoring Notifications/JMX Monitoring Notifiers Configuration.adoc[JMX Monitoring Notifiers Configuration]
-*** Request Tracing Service
-**** xref:Technical Documentation/Payara Server Documentation/Logging and Monitoring/Request Tracing Service/Overview.adoc[Overview]
-**** xref:Technical Documentation/Payara Server Documentation/Logging and Monitoring/Request Tracing Service/Asadmin Commands.adoc[Asadmin Commands]
-**** xref:Technical Documentation/Payara Server Documentation/Logging and Monitoring/Request Tracing Service/Configuration.adoc[Configuration]
-**** xref:Technical Documentation/Payara Server Documentation/Logging and Monitoring/Request Tracing Service/Terminology.adoc[Terminology]
-**** xref:Technical Documentation/Payara Server Documentation/Logging and Monitoring/Request Tracing Service/Usage.adoc[Usage]
-** Management and Monitoring REST API
-*** xref:Technical Documentation/Payara Server Documentation/Management and Monitoring REST API/Definitions.adoc[Definitions]
-*** xref:Technical Documentation/Payara Server Documentation/Management and Monitoring REST API/Rest API.adoc[Rest API]
+** Development Debugging And Assistance Tools
+*** xref:Technical Documentation/Payara Server Documentation/Development Debugging And Assistance Tools/CDI.adoc[CDI]
 ** Server Configuration And Management
+*** JDBC Resource Management
+**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/JDBC Resource Management/JDBC.adoc[JDBC]
+**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/JDBC Resource Management/SQL.adoc[SQL]
 *** Admin Console Enhancements
 **** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Admin Console Enhancements/Overview.adoc[Overview]
-**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Admin Console Enhancements/Asadmin Recorder.adoc[Asadmin Recorder]
 **** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Admin Console Enhancements/Auditing Service.adoc[Auditing Service]
 **** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Admin Console Enhancements/Environment Warning.adoc[Environment Warning]
-*** Application Deployment
-**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Application Deployment/Overview.adoc[Overview]
-**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Application Deployment/Concurrent CDI Bean Loading.adoc[Concurrent CDI Bean Loading]
-**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Application Deployment/Deployment Descriptors.adoc[Deployment Descriptors]
-**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Application Deployment/Descriptor Elements.adoc[Descriptor Elements]
-*** Asadmin Commands
-**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Asadmin Commands/Auto Naming.adoc[Auto Naming]
-**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Asadmin Commands/Multimode Event Designators Support.adoc[Multimode Event Designators Support]
-**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Asadmin Commands/Print Certificate Data.adoc[Print Certificate Data]
-**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Asadmin Commands/Server Management Asadmin Commands.adoc[Server Management Asadmin Commands]
-**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Asadmin Commands/Upgrade Payara.adoc[Upgrade Payara]
+**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Admin Console Enhancements/Asadmin Recorder.adoc[Asadmin Recorder]
+*** Security Configuration
+**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Security Configuration/Overview.adoc[Overview]
+**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Security Configuration/Multiple Mechanism in EAR.adoc[Multiple Mechanism in EAR]
+**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Security Configuration/JACC.adoc[JACC]
+**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Security Configuration/JCE Provider Support.adoc[JCE Provider Support]
+**** Client Certificates
+***** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Security Configuration/Client Certificates/Custom Validators.adoc[Custom Validators]
+***** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Security Configuration/Client Certificates/Advanced Groups Configuration.adoc[Advanced Groups Configuration]
+***** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Security Configuration/Client Certificates/Advanced Principal Name Configuration.adoc[Advanced Principal Name Configuration]
+*** Thread Pools
+**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Thread Pools/Default Thread Pool Size.adoc[Default Thread Pool Size]
 *** Classloading
 **** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Classloading/Overview.adoc[Overview]
-**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Classloading/Enhanced Classloading.adoc[Enhanced Classloading]
 **** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Classloading/Standard Classloading.adoc[Standard Classloading]
+**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Classloading/Enhanced Classloading.adoc[Enhanced Classloading]
+*** Application Deployment
+**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Application Deployment/Overview.adoc[Overview]
+**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Application Deployment/Descriptor Elements.adoc[Descriptor Elements]
+**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Application Deployment/Deployment Descriptors.adoc[Deployment Descriptors]
+**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Application Deployment/Concurrent CDI Bean Loading.adoc[Concurrent CDI Bean Loading]
+*** Docker Host Support
+**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Docker Host Support/Docker Nodes.adoc[Docker Nodes]
+**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Docker Host Support/Docker Instances.adoc[Docker Instances]
 *** Configuration Options
-**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Configuration Options/JVM Options.adoc[JVM Options]
 **** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Configuration Options/Password Aliases.adoc[Password Aliases]
 **** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Configuration Options/Phone Home.adoc[Phone Home]
+**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Configuration Options/JVM Options.adoc[JVM Options]
 **** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Configuration Options/Integrated Certificate Management.adoc[Integrated Certificate Management]
 **** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Configuration Options/SSL Certificates.adoc[SSL Certificates]
 **** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Configuration Options/System Properties.adoc[System Properties]
 **** Variable Substitution
-***** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Configuration Options/Variable Substitution/Types of Variables.adoc[Types of Variables]
 ***** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Configuration Options/Variable Substitution/Usage of Variables.adoc[Usage of Variables]
-*** Docker Host Support
-**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Docker Host Support/Docker Instances.adoc[Docker Instances]
-**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Docker Host Support/Docker Nodes.adoc[Docker Nodes]
-*** Domain Data Grid And Hazelcast
-**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Domain Data Grid And Hazelcast/Overview.adoc[Overview]
-**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Domain Data Grid And Hazelcast/Configuration.adoc[Configuration]
-**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Domain Data Grid And Hazelcast/Datagrid in Applications.adoc[Datagrid in Applications]
-**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Domain Data Grid And Hazelcast/Discovery.adoc[Discovery]
-**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Domain Data Grid And Hazelcast/Encryption.adoc[Encryption]
-**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Domain Data Grid And Hazelcast/Viewing Members.adoc[Viewing Members]
+***** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Configuration Options/Variable Substitution/Types of Variables.adoc[Types of Variables]
 *** HTTP Service
 **** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/HTTP Service/Overview.adoc[Overview]
-**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/HTTP Service/Network Listeners.adoc[Network Listeners]
 **** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/HTTP Service/Protocols.adoc[Protocols]
 **** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/HTTP Service/Virtual Servers.adoc[Virtual Servers]
-*** JDBC Resource Management
-**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/JDBC Resource Management/JDBC.adoc[JDBC]
-**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/JDBC Resource Management/SQL.adoc[SQL]
-*** Security Configuration
-**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Security Configuration/Overview.adoc[Overview]
-**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Security Configuration/JACC.adoc[JACC]
-**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Security Configuration/JCE Provider Support.adoc[JCE Provider Support]
-**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Security Configuration/Multiple Mechanism in EAR.adoc[Multiple Mechanism in EAR]
-**** Client Certificates
-***** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Security Configuration/Client Certificates/Advanced Groups Configuration.adoc[Advanced Groups Configuration]
-***** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Security Configuration/Client Certificates/Advanced Principal Name Configuration.adoc[Advanced Principal Name Configuration]
-***** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Security Configuration/Client Certificates/Custom Validators.adoc[Custom Validators]
-*** Thread Pools
-**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Thread Pools/Default Thread Pool Size.adoc[Default Thread Pool Size]
+**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/HTTP Service/Network Listeners.adoc[Network Listeners]
+*** Asadmin Commands
+**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Asadmin Commands/Server Management Asadmin Commands.adoc[Server Management Asadmin Commands]
+**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Asadmin Commands/Multimode Event Designators Support.adoc[Multimode Event Designators Support]
+**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Asadmin Commands/Upgrade Payara.adoc[Upgrade Payara]
+**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Asadmin Commands/Auto Naming.adoc[Auto Naming]
+**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Asadmin Commands/Print Certificate Data.adoc[Print Certificate Data]
+*** Domain Data Grid And Hazelcast
+**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Domain Data Grid And Hazelcast/Overview.adoc[Overview]
+**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Domain Data Grid And Hazelcast/Datagrid in Applications.adoc[Datagrid in Applications]
+**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Domain Data Grid And Hazelcast/Configuration.adoc[Configuration]
+**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Domain Data Grid And Hazelcast/Encryption.adoc[Encryption]
+**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Domain Data Grid And Hazelcast/Viewing Members.adoc[Viewing Members]
+**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Domain Data Grid And Hazelcast/Discovery.adoc[Discovery]
+** Deployment Groups
+*** xref:Technical Documentation/Payara Server Documentation/Deployment Groups/Overview.adoc[Overview]
+*** xref:Technical Documentation/Payara Server Documentation/Deployment Groups/Asadmin Commands.adoc[Asadmin Commands]
+*** xref:Technical Documentation/Payara Server Documentation/Deployment Groups/Timers.adoc[Timers]
+** Jakarta EE API
+*** xref:Technical Documentation/Payara Server Documentation/Jakarta EE API/JCache API.adoc[JCache API]
+*** xref:Technical Documentation/Payara Server Documentation/Jakarta EE API/JAX-WS Enhancements.adoc[JAX-WS Enhancements]
+*** xref:Technical Documentation/Payara Server Documentation/Jakarta EE API/JavaMail API.adoc[JavaMail API]
+*** JAX-RS
+**** xref:Technical Documentation/Payara Server Documentation/Jakarta EE API/JAX-RS/CDI With JAX-RS.adoc[CDI With JAX-RS]
+*** Enterprise Java Beans (EJB)
+**** xref:Technical Documentation/Payara Server Documentation/Jakarta EE API/Enterprise Java Beans (EJB)/Overview.adoc[Overview]
+**** xref:Technical Documentation/Payara Server Documentation/Jakarta EE API/Enterprise Java Beans (EJB)/Tracing Remote EJBs.adoc[Tracing Remote EJBs]
+*** JPA
+**** xref:Technical Documentation/Payara Server Documentation/Jakarta EE API/JPA/JPA Cache Coordination.adoc[JPA Cache Coordination]
+*** JSF API
+**** xref:Technical Documentation/Payara Server Documentation/Jakarta EE API/JSF API/JSF Options.adoc[JSF Options]
+*** JBatch API
+**** xref:Technical Documentation/Payara Server Documentation/Jakarta EE API/JBatch API/Overview.adoc[Overview]
+**** xref:Technical Documentation/Payara Server Documentation/Jakarta EE API/JBatch API/Schema Name.adoc[Schema Name]
+**** xref:Technical Documentation/Payara Server Documentation/Jakarta EE API/JBatch API/Table Prefix and Suffix.adoc[Table Prefix and Suffix]
+**** xref:Technical Documentation/Payara Server Documentation/Jakarta EE API/JBatch API/Database Support.adoc[Database Support]
+**** xref:Technical Documentation/Payara Server Documentation/Jakarta EE API/JBatch API/Improved Asadmin CLI.adoc[Improved Asadmin CLI]
+** Logging and Monitoring
+*** xref:Technical Documentation/Payara Server Documentation/Logging and Monitoring/Logging.adoc[Logging]
+*** xref:Technical Documentation/Payara Server Documentation/Logging and Monitoring/Payara InSight.adoc[Payara InSight]
+*** xref:Technical Documentation/Payara Server Documentation/Logging and Monitoring/HealthCheck Service.adoc[HealthCheck Service]
+*** Request Tracing Service
+**** xref:Technical Documentation/Payara Server Documentation/Logging and Monitoring/Request Tracing Service/Overview.adoc[Overview]
+**** xref:Technical Documentation/Payara Server Documentation/Logging and Monitoring/Request Tracing Service/Terminology.adoc[Terminology]
+**** xref:Technical Documentation/Payara Server Documentation/Logging and Monitoring/Request Tracing Service/Configuration.adoc[Configuration]
+**** xref:Technical Documentation/Payara Server Documentation/Logging and Monitoring/Request Tracing Service/Asadmin Commands.adoc[Asadmin Commands]
+**** xref:Technical Documentation/Payara Server Documentation/Logging and Monitoring/Request Tracing Service/Usage.adoc[Usage]
+*** Notification Service
+**** xref:Technical Documentation/Payara Server Documentation/Logging and Monitoring/Notification Service/Overview.adoc[Overview]
+**** Notifiers
+***** xref:Technical Documentation/Payara Server Documentation/Logging and Monitoring/Notification Service/Notifiers/New Relic Notifier.adoc[New Relic Notifier]
+***** xref:Technical Documentation/Payara Server Documentation/Logging and Monitoring/Notification Service/Notifiers/SNMP Notifier.adoc[SNMP Notifier]
+***** xref:Technical Documentation/Payara Server Documentation/Logging and Monitoring/Notification Service/Notifiers/Discord Notifier.adoc[Discord Notifier]
+***** xref:Technical Documentation/Payara Server Documentation/Logging and Monitoring/Notification Service/Notifiers/Custom Notifier.adoc[Custom Notifier]
+***** xref:Technical Documentation/Payara Server Documentation/Logging and Monitoring/Notification Service/Notifiers/Log Notifier.adoc[Log Notifier]
+***** xref:Technical Documentation/Payara Server Documentation/Logging and Monitoring/Notification Service/Notifiers/JMS Notifier.adoc[JMS Notifier]
+***** xref:Technical Documentation/Payara Server Documentation/Logging and Monitoring/Notification Service/Notifiers/XMPP Notifier.adoc[XMPP Notifier]
+***** xref:Technical Documentation/Payara Server Documentation/Logging and Monitoring/Notification Service/Notifiers/CDI Event Bus Notifier.adoc[CDI Event Bus Notifier]
+***** xref:Technical Documentation/Payara Server Documentation/Logging and Monitoring/Notification Service/Notifiers/Event Bus Notifier.adoc[Event Bus Notifier]
+***** xref:Technical Documentation/Payara Server Documentation/Logging and Monitoring/Notification Service/Notifiers/Slack Notifier.adoc[Slack Notifier]
+***** xref:Technical Documentation/Payara Server Documentation/Logging and Monitoring/Notification Service/Notifiers/Email Notifier.adoc[Email Notifier]
+***** xref:Technical Documentation/Payara Server Documentation/Logging and Monitoring/Notification Service/Notifiers/Teams Notifier.adoc[Teams Notifier]
+***** xref:Technical Documentation/Payara Server Documentation/Logging and Monitoring/Notification Service/Notifiers/Datadog Notifier.adoc[Datadog Notifier]
+**** JMX Monitoring Notifications
+***** xref:Technical Documentation/Payara Server Documentation/Logging and Monitoring/Notification Service/JMX Monitoring Notifications/JMX Monitoring Notifiers Asadmin Commands.adoc[JMX Monitoring Notifiers Asadmin Commands]
+***** xref:Technical Documentation/Payara Server Documentation/Logging and Monitoring/Notification Service/JMX Monitoring Notifications/JMX Monitoring Notifiers Configuration.adoc[JMX Monitoring Notifiers Configuration]
+*** Monitoring Service
+**** xref:Technical Documentation/Payara Server Documentation/Logging and Monitoring/Monitoring Service/Rest Monitoring.adoc[Rest Monitoring]
+**** xref:Technical Documentation/Payara Server Documentation/Logging and Monitoring/Monitoring Service/MBeans.adoc[MBeans]
+**** xref:Technical Documentation/Payara Server Documentation/Logging and Monitoring/Monitoring Service/JMX Monitoring.adoc[JMX Monitoring]
+**** xref:Technical Documentation/Payara Server Documentation/Logging and Monitoring/Monitoring Service/Basic Monitoring Configuration.adoc[Basic Monitoring Configuration]
+** Management and Monitoring REST API
+*** xref:Technical Documentation/Payara Server Documentation/Management and Monitoring REST API/Rest API.adoc[Rest API]
+*** xref:Technical Documentation/Payara Server Documentation/Management and Monitoring REST API/Definitions.adoc[Definitions]
+* Ecosystem
+** xref:Technical Documentation/Ecosystem/Overview.adoc[Overview]
+** Miscellaneous
+*** xref:Technical Documentation/Ecosystem/Miscellaneous/JAX-RS Extension.adoc[JAX-RS Extension]
+** Project Management Tools
+*** xref:Technical Documentation/Ecosystem/Project Management Tools/Gradle Plugin.adoc[Gradle Plugin]
+*** xref:Technical Documentation/Ecosystem/Project Management Tools/Maven Bom.adoc[Maven Bom]
+*** xref:Technical Documentation/Ecosystem/Project Management Tools/Maven Archetype.adoc[Maven Archetype]
+*** xref:Technical Documentation/Ecosystem/Project Management Tools/Maven Plugin.adoc[Maven Plugin]
+** Connector Suites
+*** xref:Technical Documentation/Ecosystem/Connector Suites/Security Connectors.adoc[Security Connectors]
+*** Cloud Connectors
+**** xref:Technical Documentation/Ecosystem/Connector Suites/Cloud Connectors/Overview.adoc[Overview]
+**** xref:Technical Documentation/Ecosystem/Connector Suites/Cloud Connectors/Amazon SQS.adoc[Amazon SQS]
+**** xref:Technical Documentation/Ecosystem/Connector Suites/Cloud Connectors/Azure SB.adoc[Azure SB]
+**** xref:Technical Documentation/Ecosystem/Connector Suites/Cloud Connectors/Apache Kafka.adoc[Apache Kafka]
+**** xref:Technical Documentation/Ecosystem/Connector Suites/Cloud Connectors/MQTT.adoc[MQTT]
+*** Arquillian Containers
+**** xref:Technical Documentation/Ecosystem/Connector Suites/Arquillian Containers/Overview.adoc[Overview]
+**** xref:Technical Documentation/Ecosystem/Connector Suites/Arquillian Containers/Payara Micro Managed.adoc[Payara Micro Managed]
+**** xref:Technical Documentation/Ecosystem/Connector Suites/Arquillian Containers/Payara Server Remote.adoc[Payara Server Remote]
+**** xref:Technical Documentation/Ecosystem/Connector Suites/Arquillian Containers/Payara Server Managed.adoc[Payara Server Managed]
+**** xref:Technical Documentation/Ecosystem/Connector Suites/Arquillian Containers/Payara Server Embedded.adoc[Payara Server Embedded]
+** IDE Integration
+*** Eclipse Plugin
+**** xref:Technical Documentation/Ecosystem/IDE Integration/Eclipse Plugin/Overview.adoc[Overview]
+**** xref:Technical Documentation/Ecosystem/IDE Integration/Eclipse Plugin/Payara Server.adoc[Payara Server]
+**** xref:Technical Documentation/Ecosystem/IDE Integration/Eclipse Plugin/Payara Micro.adoc[Payara Micro]
+*** NetBeans Plugin
+**** xref:Technical Documentation/Ecosystem/IDE Integration/NetBeans Plugin/Overview.adoc[Overview]
+**** xref:Technical Documentation/Ecosystem/IDE Integration/NetBeans Plugin/Payara Server.adoc[Payara Server]
+**** xref:Technical Documentation/Ecosystem/IDE Integration/NetBeans Plugin/Payara Micro.adoc[Payara Micro]
+*** VSCode Extension
+**** xref:Technical Documentation/Ecosystem/IDE Integration/VSCode Extension/Overview.adoc[Overview]
+**** xref:Technical Documentation/Ecosystem/IDE Integration/VSCode Extension/Payara Server.adoc[Payara Server]
+**** xref:Technical Documentation/Ecosystem/IDE Integration/VSCode Extension/Payara Micro.adoc[Payara Micro]
+*** Intellij Plugin
+**** xref:Technical Documentation/Ecosystem/IDE Integration/Intellij Plugin/Overview.adoc[Overview]
+**** xref:Technical Documentation/Ecosystem/IDE Integration/Intellij Plugin/Payara Server.adoc[Payara Server]
+**** xref:Technical Documentation/Ecosystem/IDE Integration/Intellij Plugin/Payara Micro.adoc[Payara Micro]
+* MicroProfile
+** xref:Technical Documentation/MicroProfile/Overview.adoc[Overview]
+** xref:Technical Documentation/MicroProfile/JWT.adoc[JWT]
+** xref:Technical Documentation/MicroProfile/Rest Client.adoc[Rest Client]
+** xref:Technical Documentation/MicroProfile/OpenAPI.adoc[OpenAPI]
+** xref:Technical Documentation/MicroProfile/Fault Tolerance.adoc[Fault Tolerance]
+** xref:Technical Documentation/MicroProfile/HealthCheck.adoc[HealthCheck]
+** xref:Technical Documentation/MicroProfile/Opentracing.adoc[Opentracing]
+** Metrics
+*** xref:Technical Documentation/MicroProfile/Metrics/Metrics Rest Endpoint.adoc[Metrics Rest Endpoint]
+*** xref:Technical Documentation/MicroProfile/Metrics/Vendor Metrics.adoc[Vendor Metrics]
+*** xref:Technical Documentation/MicroProfile/Metrics/Metrics Configuration.adoc[Metrics Configuration]
+** Config
+*** xref:Technical Documentation/MicroProfile/Config/Overview.adoc[Overview]
+*** xref:Technical Documentation/MicroProfile/Config/JDBC.adoc[JDBC]
+*** xref:Technical Documentation/MicroProfile/Config/LDAP.adoc[LDAP]
+*** xref:Technical Documentation/MicroProfile/Config/Directory.adoc[Directory]
+*** Cloud
+**** xref:Technical Documentation/MicroProfile/Config/Cloud/Overview.adoc[Overview]
+**** xref:Technical Documentation/MicroProfile/Config/Cloud/GCP.adoc[GCP]
+**** xref:Technical Documentation/MicroProfile/Config/Cloud/Hashicorp.adoc[Hashicorp]
+**** xref:Technical Documentation/MicroProfile/Config/Cloud/DynamoDB.adoc[DynamoDB]
+**** xref:Technical Documentation/MicroProfile/Config/Cloud/AWS.adoc[AWS]
+**** xref:Technical Documentation/MicroProfile/Config/Cloud/Azure.adoc[Azure]
 * Public API
 ** xref:Technical Documentation/Public API/Overview.adoc[Overview]
+** xref:Technical Documentation/Public API/Roles Permitted.adoc[Roles Permitted]
 ** xref:Technical Documentation/Public API/CDI Events.adoc[CDI Events]
-** xref:Technical Documentation/Public API/Clustered Singleton.adoc[Clustered Singleton]
 ** xref:Technical Documentation/Public API/OAuth Support.adoc[OAuth Support]
 ** xref:Technical Documentation/Public API/OpenID Connect Support.adoc[OpenID Connect Support]
-** xref:Technical Documentation/Public API/Roles Permitted.adoc[Roles Permitted]
 ** xref:Technical Documentation/Public API/Security Extensions.adoc[Security Extensions]
+** xref:Technical Documentation/Public API/Clustered Singleton.adoc[Clustered Singleton]
 ** xref:Technical Documentation/Public API/Yubikey.adoc[Yubikey]
 
 include::partial$release-notes.adoc[Release Notes]
@@ -269,5 +269,5 @@ include::partial$eclipse-microprofile.adoc[Eclipse MicroProfile Certification]
 .Appendix
 * Schemas
 ** xref:Appendix/Schemas/Overview.adoc[Overview]
-** xref:Appendix/Schemas/payara-resources_1_6.dtd[payara-resources_1_6.dtd]
 ** xref:Appendix/Schemas/payara-web-app_4.dtd[payara-web-app_4.dtd]
+** xref:Appendix/Schemas/payara-resources_1_6.dtd[payara-resources_1_6.dtd]

--- a/enterprise/docs/modules/ROOT/pages/Technical Documentation/Payara Micro Documentation/Payara Micro Docker Image.adoc
+++ b/enterprise/docs/modules/ROOT/pages/Technical Documentation/Payara Micro Documentation/Payara Micro Docker Image.adoc
@@ -24,7 +24,7 @@ IMPORTANT: It is recommended to specify the tag name of the Docker image that yo
 [source, shell, subs=attributes+]
 .Using a specific version
 ----
-docker run -p 8080:8080 nexus.payara.fish:5000/payara/micro:{currentVersion}
+docker run -p 8080:8080 nexus.payara.fish:5000/payara/micro:{page-version}
 ----
 
 [[jdk-version]]
@@ -40,14 +40,14 @@ To switch from the default JDK 8 based image to the JDK 11 compatible one, just 
 
 [source, shell]
 ----
-docker run -p 8080:8080 nexus.payara.fish:5000/payara/micro:{currentVersion}-jdk11
+docker run -p 8080:8080 nexus.payara.fish:5000/payara/micro:{page-version}-jdk11
 ----
 
 To switch from the default JDK 8 based image to the JDK 17 compatible one, just add the corresponding suffix to the tag's name like this:
 
 [source, shell]
 ----
-docker run -p 8080:8080 nexus.payara.fish:5000/payara/micro:{currentVersion}-jdk17
+docker run -p 8080:8080 nexus.payara.fish:5000/payara/micro:{page-version}-jdk17
 ----
 
 [[ports]]
@@ -86,7 +86,7 @@ The following command will start a new Payara Micro instance container and deplo
 [source, shell, subs=attributes+]
 ----
 docker run -p 8080:8080 \
- -v ~/payara-micro/applications:/opt/payara/deployments nexus.payara.fish:5000/payara/micro:{currentVersion}
+ -v ~/payara-micro/applications:/opt/payara/deployments nexus.payara.fish:5000/payara/micro:{page-version}
 ----
 
 To only deploy a specific artefact within the directory, simply pass the `--deploy` argument to the container's run command and specify which application to deploy:
@@ -95,7 +95,7 @@ To only deploy a specific artefact within the directory, simply pass the `--depl
 ----
 docker run -p 8080:8080 \
  -v ~/payara-micro/applications:/opt/payara/deployments \
- nexus.payara.fish:5000/payara/micro:{currentVersion} --deploy /opt/payara/deployments/myapplication.war
+ nexus.payara.fish:5000/payara/micro:{page-version} --deploy /opt/payara/deployments/myapplication.war
 ----
 
 NOTE: Make sure to prefix the artefact names with the absolute path to the local deployment directory.
@@ -109,7 +109,7 @@ The following sample _Dockerfile_ can be used to prepare a custom Payara Micro i
 
 [source, docker, subs=attributes+]
 ----
-FROM nexus.payara.fish:5000/payara/micro:{currentVersion}
+FROM nexus.payara.fish:5000/payara/micro:{page-version}
 COPY myapplication.war $DEPLOY_DIR
 ----
 
@@ -122,7 +122,7 @@ Here's an example of how to deploy a sample application located in a local Maven
 
 [source, shell, subs=attributes+]
 ----
-docker run -p 8080:8080 nexus.payara.fish:5000/payara/micro:{currentVersion} \
+docker run -p 8080:8080 nexus.payara.fish:5000/payara/micro:{page-version} \
  --deployFromGAV "fish.payara.examples:my-application:1.0-SNAPSHOT" \
  --additionalRepository https://172.17.0.10/content/repositories/snapshots
 ----
@@ -145,7 +145,7 @@ Here are some basic examples:
 .One application deployed, uses the `myRoot` context root
 ----
 docker run -p 8080:8080 \
- -v ~/payara-micro/applications:/opt/payara/deployments nexus.payara.fish:5000/payara/micro:{currentVersion}  \
+ -v ~/payara-micro/applications:/opt/payara/deployments nexus.payara.fish:5000/payara/micro:{page-version}  \
 --deploymentDir /opt/payara/deployments  \
  --contextroot myRoot
 ----
@@ -155,7 +155,7 @@ docker run -p 8080:8080 \
 ----
 docker run -p 8080:8080 \
  -v ~/payara-micro/applications:/opt/payara/deployments \
- nexus.payara.fish:5000/payara/micro:{currentVersion} \
+ nexus.payara.fish:5000/payara/micro:{page-version} \
  --deploy /opt/payara/deployments/myapplication.war \
  --contextroot ROOT
 ----
@@ -164,7 +164,7 @@ You can also prepare a custom Docker image that overrides the default `CMD` inst
 
 [source, Docker, subs=attributes+]
 ----
-FROM nexus.payara.fish:5000/payara/micro:{currentVersion}
+FROM nexus.payara.fish:5000/payara/micro:{page-version}
 COPY myapplication.war $DEPLOY_DIR
 CMD ["--deploymentDir", "/opt/payara/deployments", "--contextroot", "my"]
 ----
@@ -181,7 +181,7 @@ To disable the Data Grid, you can pass the `--noCluster` argument to the entry p
 [source, shell, subs=attributes+]
 ----
 docker run -p 8080:8080 \
- -v ~/payara-micro/applications:/opt/payara/deployments nexus.payara.fish:5000/payara/micro:{currentVersion} --noCluster
+ -v ~/payara-micro/applications:/opt/payara/deployments nexus.payara.fish:5000/payara/micro:{page-version} --noCluster
 ----
 
 [[using-environment-variables]]

--- a/enterprise/docs/modules/ROOT/pages/Technical Documentation/Payara Server Documentation/Payara Server Docker Image.adoc
+++ b/enterprise/docs/modules/ROOT/pages/Technical Documentation/Payara Server Documentation/Payara Server Docker Image.adoc
@@ -24,7 +24,7 @@ IMPORTANT: It is recommended to specify the tag of the correct Payara Enterprise
 [source, shell, subs=attributes+]
 .Using a specific version
 ----
-docker run -p 8080:8080 nexus.payara.fish:5000/payara/server-full:{currentVersion}
+docker run -p 8080:8080 nexus.payara.fish:5000/payara/server-full:{page-version}
 ----
 
 [[other-distributions]]
@@ -45,14 +45,14 @@ To switch from the default JDK 8 based image to the JDK 11 compatible one, just 
 
 [source, shell, subs=attributes+]
 ----
-docker run -p 8080:8080 nexus.payara.fish:5000/payara/server-full:{currentVersion}-jdk11
+docker run -p 8080:8080 nexus.payara.fish:5000/payara/server-full:{page-version}-jdk11
 ----
 
 To switch from the default JDK 8 based image to the JDK 17 compatible one, just add the corresponding suffix to the tag's name like this:
 
 [source, shell, subs=attributes+]
 ----
-docker run -p 8080:8080 nexus.payara.fish:5000/payara/server-full:{currentVersion}-jdk17
+docker run -p 8080:8080 nexus.payara.fish:5000/payara/server-full:{page-version}-jdk17
 ----
 
 [[ports]]
@@ -72,7 +72,7 @@ To access the DAS' administration interface (either by remote asadmin commands o
 
 [source, shell, subs=attributes+]
 ----
-docker run -p 4848:4848 -p 8080:8080 nexus.payara.fish:5000/payara/server-full:{currentVersion}
+docker run -p 4848:4848 -p 8080:8080 nexus.payara.fish:5000/payara/server-full:{page-version}
 ----
 
 By default, the admin service will be secure-enabled, meaning that HTTPS communication will be used exclusively.
@@ -104,7 +104,7 @@ The following sample command will launch a new Payara Server container and deplo
 
 [source, shell, subs=attributes+]
 ----
-docker run -p 8080:8080 -v ~/payara/apps:/opt/payara/deployments nexus.payara.fish:5000/payara/server-full:{currentVersion}
+docker run -p 8080:8080 -v ~/payara/apps:/opt/payara/deployments nexus.payara.fish:5000/payara/server-full:{page-version}
 ----
 
 [[deploy-using-custom-image]]
@@ -116,7 +116,7 @@ The following sample _Dockerfile_ can be used to prepare a custom Payara Server 
 
 [source, Docker, subs=attributes+]
 ----
-FROM nexus.payara.fish:5000/payara/server-full:{currentVersion}
+FROM nexus.payara.fish:5000/payara/server-full:{page-version}
 COPY myapplication.war $DEPLOY_DIR
 ----
 
@@ -175,14 +175,14 @@ For example, the following sample command will execute all commands listed in th
 
 [source, shell, subs=attributes+]
 ----
-docker run -p 8080:8080 -v /local/path/with/boot/file:/config -e POSTBOOT_COMMANDS=/config/post-boot-commands.asadmin nexus.payara.fish:5000/payara/server-full:{currentVersion}
+docker run -p 8080:8080 -v /local/path/with/boot/file:/config -e POSTBOOT_COMMANDS=/config/post-boot-commands.asadmin nexus.payara.fish:5000/payara/server-full:{page-version}
 ----
 
 Alternatively, the same outcome can be achieved by defining a custom Docker image:
 
 [source, Docker, subs=attributes+]
 ----
-FROM nexus.payara.fish:5000/payara/server-full:{currentVersion}
+FROM nexus.payara.fish:5000/payara/server-full:{page-version}
 COPY post-boot-commands.asadmin $POSTBOOT_COMMANDS
 ----
 
@@ -215,5 +215,5 @@ You can override the default entrypoint if needed to test or browse the containe
 
 [source, shell, subs=attributes+]
 ----
-docker run -p 8080:8080 -it nexus.payara.fish:5000/payara/server-full:{currentVersion} bash
+docker run -p 8080:8080 -it nexus.payara.fish:5000/payara/server-full:{page-version} bash
 ----


### PR DESCRIPTION
Antora provides the `page-version` attribute, which is a shortform alias for page-component-version. It will output the current version set in antora.yml, e.g. 5.2022.3 or 5.41.0, etc.

currentVersion is only updated during release, meaning it will match the version in antora.yml, meaning it is redundant and we can utilize the Antora attribute.