### PR TITLE
SERV-793 Document CVE-2020-36518 fix in Security Fixes

### DIFF
--- a/community/docs/modules/ROOT/pages/Security/Security Fix List.adoc
+++ b/community/docs/modules/ROOT/pages/Security/Security Fix List.adoc
@@ -7,6 +7,8 @@ The following is a list of tracked _**C**ommon **V**ulnerabilities and **E**xpos
 |=======================================================================
 |ID |CVSS v3.0 Base Score |Status |Summary |Release |Pull Requests |Observations
 
+|https://nvd.nist.gov/vuln/detail/CVE-2020-36518[CVE-2020-36518] | 7.5 | FIXED | jackson-databind allows a Java StackOverflow exception and denial of service via a large depth of nested objects. | 5.2022.2 | https://github.com/payara/Payara/pull/5695[#5695] | Fixed by upgrading jackson-databind to 2.12.6.1
+
 |https://nvd.nist.gov/vuln/detail/CVE-2018-25032[CVE-2018-25032] | 7.5 | FIXED | ZLib allows memory corruption when deflating (i.e. when compressing) if the input has many distant matches. | 5.2022.2 | https://github.com/payara/Payara/pull/5638[#5638] | Fixed by upgrading to Azul JDK version using ZLib 1.2.12 in Payara Docker Images.
 
 |https://nvd.nist.gov/vuln/detail/cve-2022-22965[CVE-2022-22965] | 9.8 | FIXED | A Spring MVC or Spring WebFlux application running on JDK 9+ may be vulnerable to remote code execution (RCE) via data binding. | 5.2022.2 | https://github.com/payara/Payara/pull/5686[#5686] | The original vulnerability is in the Spring Framework 5.3.0 to 5.3.17, 5.2.0 to 5.2.19, and older versions. The fix in the Payara Platform mitigates the Spring vulnerability by blocking the Payara classloader from giving access to Payara Platform internals.

--- a/enterprise/docs/modules/ROOT/pages/Security/Security Fix List.adoc
+++ b/enterprise/docs/modules/ROOT/pages/Security/Security Fix List.adoc
@@ -7,6 +7,8 @@ The following is a list of tracked _**C**ommon **V**ulnerabilities and **E**xpos
 |=======================================================================
 |ID |CVSS v3.0 Base Score |Status |Summary |Release |Observations
 
+|https://nvd.nist.gov/vuln/detail/CVE-2020-36518[CVE-2020-36518] | 7.5 | FIXED | jackson-databind allows a Java StackOverflow exception and denial of service via a large depth of nested objects. | 5.38.0 | Fixed by upgrading jackson-databind to 2.12.6.1
+
 |https://nvd.nist.gov/vuln/detail/CVE-2018-25032[CVE-2018-25032] | 7.5 | FIXED | ZLib allows memory corruption when deflating (i.e. when compressing) if the input has many distant matches. | 5.38.0 | Fixed by upgrading to Azul JDK version using ZLib 1.2.12 in Payara Docker Images.
 
 |https://nvd.nist.gov/vuln/detail/cve-2022-22965[CVE-2022-22965] | 9.8 | FIXED | A Spring MVC or Spring WebFlux application running on JDK 9+ may be vulnerable to remote code execution (RCE) via data binding. | 5.38.0 | The original vulnerability is in the Spring Framework 5.3.0 to 5.3.17, 5.2.0 to 5.2.19, and older versions. The fix in the Payara Platform mitigates the Spring vulnerability by blocking the Payara classloader from giving access to Payara Platform internals.


### PR DESCRIPTION
When CVE-2020-36518 was fixed there was no PR to document it in the fixes list. Documenting this CVE now.

**CVE:** https://nvd.nist.gov/vuln/detail/CVE-2020-36518