### PR TITLE
SERV-797 Upgrade Tool Incorrectly Documents Downgrading Version

### DIFF
--- a/enterprise/docs/modules/ROOT/pages/Technical Documentation/Payara Server Documentation/Upgrade Tool/Overview.adoc
+++ b/enterprise/docs/modules/ROOT/pages/Technical Documentation/Payara Server Documentation/Upgrade Tool/Overview.adoc
@@ -2,7 +2,7 @@
 = Payara Server Upgrade Tool
 :page-aliases: upgrade-server.adoc
 
-This tool can be used to upgrade an existing Payara Server installation to a newer version. The Upgrade Tool is bundled in Payara Server versions starting from release `5.24.0` and is mantained as a separate JAR artifact under the `fish.payara.extras: payara-upgrade-tool` GAV coordinates.
+This tool can be used to upgrade an existing Payara Server installation to a newer version. The Upgrade Tool is bundled in Payara Server versions starting from release `5.24.0` and is maintained as a separate JAR artifact under the `fish.payara.extras: payara-upgrade-tool` GAV coordinates.
 
 TIP: The upgrade tool can be manually installed to Payara Platform `5.20.0` and newer if needed. To do so, download the latest JAR release from Payara Nexus using https://nexus.payara.fish/#browse/browse:payara-enterprise-downloadable-artifacts:fish%2Fpayara%2Fextras%2Fpayara-upgrade-tool[this link] and then drop it into your Payara Server installation under the `payara5/glassfish/lib/asadmin` folder, replacing an older version of the artifact in case it exists.
 
@@ -124,7 +124,7 @@ IMPORTANT: This script cannot be used to clean up upgrades from releases prior t
 [[configure-logging-levels]]
 == Configure Logging Levels
 
-The upgrade tool commands and helper scripts will print a set of minimum details of the operations executed (upgrade, staging, rollback). For troubleshooting scenarions, or if wanting to review in detail all executed actions, the following 2 environment variables are available to control the level of logging done by the Upgrade tool:
+The upgrade tool commands and helper scripts will print a set of minimum details of the operations executed (upgrade, staging, rollback). For troubleshooting scenarios, or if wanting to review in detail all executed actions, the following 2 environment variables are available to control the level of logging done by the Upgrade tool:
 
 `AS_DEBUG`:: Set to `true` to configure the Upgrade Tool's logging level to `FINER`.
 `AS_TRACE`:: Set to `true` to configure the Upgrade Tool's logging level to `FINESET`.

--- a/enterprise/docs/modules/ROOT/pages/Technical Documentation/Payara Server Documentation/Upgrade Tool/Overview.adoc
+++ b/enterprise/docs/modules/ROOT/pages/Technical Documentation/Payara Server Documentation/Upgrade Tool/Overview.adoc
@@ -19,7 +19,7 @@ The following are the Asadmin CLI commands available to the upgrade tool.
 *Aim*::
 This command can be used to upgrade Payara Server to the specified distribution along with all SSH nodes in the `domain.xml` configuration file.
 
-The command will also back up the old version and domains in the default location (`payara5/glassfish/domains`) or the location specified using the `--domaindir` option to allow for rolling back. The command can also be used to downgrade to an older Payara version although this is not encouraged.
+The command will also back up the old version and domains in the default location (`payara5/glassfish/domains`) or the location specified using the `--domaindir` option to allow for rolling back.
 
 [[command-options-1]]
 ==== Command Options


### PR DESCRIPTION
You can't downgrade versions with the upgrade tool anymore - remove the now incorrect documentation.