### PR TITLE
SERV-40 Document JVM Settings for Encoding Config Files

### DIFF
--- a/docs/modules/ROOT/pages/Technical Documentation/Payara Server Documentation/Logging and Monitoring/Monitoring Service/JMX Monitoring.adoc
+++ b/docs/modules/ROOT/pages/Technical Documentation/Payara Server Documentation/Logging and Monitoring/Monitoring Service/JMX Monitoring.adoc
@@ -3,6 +3,8 @@
 
 Payara offers a custom JMX Monitoring Service. Once configured, Payara Server will monitor and log the values of attributes that have been listed for monitoring. The metrics are logged together in a single log message as a series of key-value pairs prefixed by the string `JMX-MONITORING:`.
 
+NOTE: The default JMX listener is unauthenticated and open for local access. In an unsecure environment, open JMX ports should be disabled to prevent unwanted access.
+
 [[enable-jmx]]
 == Enabling JMX Monitoring
 
@@ -127,4 +129,4 @@ asadmin> set-jmx-monitoring-configuration --logfrequency 60 --enabled false
 [[see-also]]
 == See Also
 
-* xref:/Technical Documentation/Payara Server Documentation/Logging and Monitoring/Notification Service/JMX Monitoring Notifications/JMX Monitoring Notifiers Configuration.adoc[Configuring Notification for JMX Monitoring]
+* xref:Technical Documentation/Payara Server Documentation/Logging and Monitoring/Notification Service/JMX Monitoring Notifications/JMX Monitoring Notifiers Configuration.adoc[Configuring Notification for JMX Monitoring]

--- a/docs/modules/ROOT/pages/Technical Documentation/Payara Server Documentation/Server Configuration And Management/Application Deployment/Deployment Descriptors.adoc
+++ b/docs/modules/ROOT/pages/Technical Documentation/Payara Server Documentation/Server Configuration And Management/Application Deployment/Deployment Descriptors.adoc
@@ -1,5 +1,6 @@
 [[overview]]
 = Payara Server Deployment Descriptor Files
+
 By default, the Payara Platform allows the use of standard GlassFish Server deployment descriptor files to configure application behaviour.
 
 [[payara-web-info]]

--- a/docs/modules/ROOT/pages/Technical Documentation/Payara Server Documentation/Server Configuration And Management/Configuration Options/JVM Options.adoc
+++ b/docs/modules/ROOT/pages/Technical Documentation/Payara Server Documentation/Server Configuration And Management/Configuration Options/JVM Options.adoc
@@ -1,24 +1,38 @@
-[[configurable-jdk-versions-jvm-options]]
-= Configurable JDK Versions for JVM Options
+[[jvm-options-overview]]
+= JVM Options
+
+Payara Server can be configured through various JVM options. By default, there are a number of JVM options configured within the `domain.xml` configuration file in each Payara Server domain. Additional JVM options can be added to control various functionality and features of Payara Server.
+
+WARNING: If you use the asadmin multimode, when creating JVM options special characters must be double escaped.
+
+[[creating-jvm-options]]
+== Creating JVM Options
+
+JVM options can be created via the Admin Console, or the `create-jvm-options` asadmin command. The jvm option key value pair must be enclosed in quotation marks.
+
+*Example:* `asadmin create-jvm-options "-Djava.awt.headless\=true"`
+
+[[deleting-jvm-options]]
+== Deleting JVM Options
+
+Deleting JVM options is done using either the Admin Console, or the `delete-jvm-options` asadmin command.
+
+*Example:* `asadmin delete-jvm-options "-Djava.awt.headless"`
+
+[[configuring-jdk-versions-jvm-options]]
+== Configuring JDK Versions for JVM Options
 
 It is possible to allow specific JVM options configured for a Payara Server instance to be applied only on specific JDK versions. The configuration is flexible since it allows the user to define minimum and maximum versions of all JDKs upon which each JVM option should be applied.
 
-NOTE: If no minimum and/or maximum JDK versions are set for a particular JVM option, it shall be applied no matter which JDK is being used to run the server's instance (which is the default behaviour).
-
-[[versioning-syntax]]
-== Versioning Syntax
-
-JDK versions must follow standard the standard JDK versioning scheme (`1.$MAJOR.$MINOR.$UPDATE`). The syntax that can be used is a bit flexible, allowing the following variants to be correctly interpreted:
+JDK versions must follow standard the standard JDK versioning scheme. The syntax that can be used allows for different levels of granularity in the specified JDK versions. Any of the following would be acceptable:
 
 * `1.8.0.162`
 * `1.8.0u162`
 * `1.8.0`
 * `1.8`
 
-[[configuring-jdk-versions]]
-== Configuring JDK Versions
 
-JDK Versions for JVM Options can be configured in three different ways: Using the admin console or running asadmin commands from a console terminal.
+NOTE: If no minimum and/or maximum JDK versions are set for a particular JVM option, it shall be applied no matter which JDK is being used to run the server's instance.
 
 [[using-admin-console]]
 === Using the Admin Console
@@ -32,9 +46,9 @@ You can omit either the minimum or maximum versions by leaving the fields blank.
 [[using-asadmin-commands]]
 === Using Asadmin commands
 
-JVM options can be configured using the 'create-jvm-options' asadmin command. The jvm option key value pair must be enclosed in quotation marks as follows: `_asadmin create-jvm-options --target=server-config "-Djava.awt.headless\=true"_`
+It is also possible to create JVM options with JDK versions using the asadmin commands.
 
-The `create-jvm-options` asadmin command has been modified to set the minimum and maximum JDK versions in the following ways:
+The `create-jvm-options` asadmin command allows the minimum and maximum JDK versions to be set in the following ways:
 
 . Use the `--min-jvm` and `--max-jvm` arguments to set the versions when running the command:
 +
@@ -57,42 +71,14 @@ asadmin create-jvm-options --target=server-config "[|1.8.0u172]-XX\:+UnlockDiagn
 
 asadmin create-jvm-options --target=server-config "[1.8.0u168|1.8.0u172]-XX\:NewRatio\=2"
 ----
-+
-You can specify the range for each JVM option when specifying multiple options too:
-+
-[source, shell]
-----
-asadmin create-jvm-options --target=server-config "-Djava.awt.headless\=true:[|1.8.0u172]-XX\:+UnlockDiagnosticVMOptions:[1.8.0u168|1.8.0u172]-XX\:NewRatio\=2"
-----
 
-[[multimode-double-escaping]]
-=== Multimode double escaping
+The `delete-jvm-options` asadmin command does not require you to specify the JDK version when deleting a JVM option, though you can if you wish.
 
-When creating JVM options in the multimode of asadmin, you need to perform a _double_ escaping of the values.
-
-So first, start up _asadmin_ in multimode.
+For example, given the option `[1.8.0.160|1.8.0.200]XX\:NewRatio=3`, either of the following commands are acceptable:
 
 [source, shell]
 ----
-asadmin
-----
+asadmin delete-jvm-options "XX\:NewRatio=3"
 
-Execute the _create_jvm_options_ but perform a double escaping of the special characters. Otherwise, the command fails with the error "JVM option ... is invalid because it does not start with a '-'".
-
-[source, shell]
-----
-asadmin> create-jvm-options "-XX\\:MaxPermSize=512m"
-----
-
-[[deleting-jvm-options]]
-=== Deleting JVM Options
-
-Deleting JVM options is done using either the Admin Console, or the `delete-jvm-options` asadmin command. It is not required for you to specify the JDK version braces for deleting a JVM option, though you can if you wish.
-
-For example, given the option "[1.8.0.160|1.8.0.200]XX\:NewRatio=3", either of the following will work:
-
-[source, shell]
-----
-asadmin> delete-jvm-options "XX\:NewRatio=3"
-asadmin> delete-jvm-options "[1.8.0.160|1.8.0.200]XX\:NewRatio=3"
+asadmin delete-jvm-options "[1.8.0.160|1.8.0.200]XX\:NewRatio=3"
 ----

--- a/docs/modules/ROOT/pages/Technical Documentation/Payara Server Documentation/Server Configuration And Management/Configuration Options/JVM Options.adoc
+++ b/docs/modules/ROOT/pages/Technical Documentation/Payara Server Documentation/Server Configuration And Management/Configuration Options/JVM Options.adoc
@@ -19,6 +19,18 @@ Deleting JVM options is done using either the Admin Console, or the `delete-jvm-
 
 *Example:* `asadmin delete-jvm-options "-Djava.awt.headless"`
 
+[[configurable-jvm-options]]
+== Configurable JVM Options
+
+This is a non-exhaustive list of configurable JVM Options for Payara Server.
+
+[[configfileencoding-option]]
+=== Config File Encoding
+
+*Property*:: `fish.payara.configFileEncoding`
+*Aim*:: Sets the domain.xml parser character encoding. The domain will fail to start if you are using characters not covered by UTF-8 in your configuration without this property configured.
+*Acceptable Values*:: Any JDK supported file encoding charset
+
 [[configuring-jdk-versions-jvm-options]]
 == Configuring JDK Versions for JVM Options
 
@@ -30,7 +42,6 @@ JDK versions must follow standard the standard JDK versioning scheme. The syntax
 * `1.8.0u162`
 * `1.8.0`
 * `1.8`
-
 
 NOTE: If no minimum and/or maximum JDK versions are set for a particular JVM option, it shall be applied no matter which JDK is being used to run the server's instance.
 


### PR DESCRIPTION
JVM Options page currently only documents JDK Versions for JVM Options (IMO not making it a JVM Options page, so I did some slight reordering of this page)

Miscellaneous JVM Options currently have no place to be documented (That I could find) so I added a section for documenting the various JVM Options.