### PR TITLE
SERV-804 Document Payara Embedded & Its JDK 17 Considerations

### DIFF
--- a/community/docs/modules/ROOT/nav.adoc
+++ b/community/docs/modules/ROOT/nav.adoc
@@ -117,6 +117,7 @@
 ***** xref:Technical Documentation/Payara Micro Documentation/Payara Micro Configuration and Management/Micro Management/Stopping and Starting Instances/Stopping Instance.adoc[Stopping Instance]
 * Payara Server Documentation
 ** xref:Technical Documentation/Payara Server Documentation/Overview.adoc[Overview]
+** xref:Technical Documentation/Payara Server Documentation/Payara Server Embedded.adoc[Payara Server Embedded]
 ** xref:Technical Documentation/Payara Server Documentation/Payara Server Docker Image.adoc[Payara Server Docker Image]
 ** Upgrade Payara
 *** xref:Technical Documentation/Payara Server Documentation/Upgrade Payara/Overview.adoc[Overview]

--- a/docs/modules/ROOT/pages/Technical Documentation/Payara Server Documentation/Payara Server Embedded.adoc
+++ b/docs/modules/ROOT/pages/Technical Documentation/Payara Server Documentation/Payara Server Embedded.adoc
@@ -12,33 +12,33 @@ Payara Embedded has two distributions, `payara-embedded-all` and `payara-embedde
 To use Payara Embedded within your project, you first need to add one of the distributions as a dependency:
 
 Payara Embedded All::
-[source,xml]
-```
+[source, xml, subs=attributes+]
+----
 <dependency>
     <groupId>fish.payara.extras</groupId>
     <artifactId>payara-embedded-all</artifactId>
     <version>{page-version}</version>
     <type>jar</type>
 </dependency>
-```
+----
 
 Payara Embedded Web::
-[source,xml]
-```
+[source,xml, subs=attributes+]
+----
 <dependency>
     <groupId>fish.payara.extras</groupId>
     <artifactId>payara-embedded-web</artifactId>
     <version>{page-version}</version>
     <type>jar</type>
 </dependency>
-```
+----
 
 [[payara-embedded-example]]
 === Example
 After adding a Payara Embedded distribution as a dependency, you can begin using Payara Embedded in your application and project. For example, the following code will create and start an embedded Payara server, with the HTTP and HTTPS listener set to ports 9080 and 9845 respectively with the application `clusterjsp.war` deployed:
 
 [source,java]
-```
+----
 import java.io.File;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -69,15 +69,17 @@ public class Main {
         }
     }
 }
-```
+----
 
 [[payara-embedded-usecases]]
-== Payara Embedded Usecases
-Overview of some expected usecases of Payara Embedded.
+== Payara Embedded Use Cases
+
+Overview of some expected use cases of Payara Embedded.
 
 [[bundle-application]]
 === Bundle your Application
-Where the installation of Payara Server and the deployment of the applications can't be done on a cetral infrastructure, you may opt to use Payara Embedded. In this case, you can bundle Payara Server with the application within a single application, which makes it easier for installing it.
+
+Where the installation of Payara Server and the deployment of the applications can't be done on a central infrastructure, you may opt to use Payara Embedded. In this case, you can bundle Payara Server with the application within a single application, which makes it easier for installing it.
 
 Instead of having the three steps, installing Payara Server, configuring the environment, and deploying the application, you can do all those steps within the application containing Payara Embedded. You only need to start the application and the system is ready to respond to user requests.
 
@@ -85,6 +87,7 @@ TIP: Unless you require specifications only in the Jakarta Full Profile, like SO
 
 [[integration-testing]]
 === Integration Testing
+
 While performing integration testing, you may need to deploy the application to Payara in order to verify the behaviour of the code you have written. While you could use a standalone installation of Payara Server, cleanup is not always done correctly and can cause other tests to behave incorrectly.
 
 Integration testing can be done easier and more consistently with Payara Embedded, you can start Payara up as the beginning of the test, verify the functionality and then use a clean instance for each test, therefore eliminating the possibility of an unexpected state in the environment.
@@ -94,7 +97,7 @@ Starting Payara Embedded for testing can also be done using the Arquillian conne
 == JDK 17 Considerations
 When running Payara Embedded on JDK 17, you must update your client side run configuration with all the necessary opens and exports for Payara to work as expected. The following JVM options should be added within your run configuration:
 
-[source,text]
-```
+[source, shell]
+----
 --add-opens=java.base/jdk.internal.loader=ALL-UNNAMED --add-opens=jdk.management/com.sun.management.internal=ALL-UNNAMED --add-exports=java.base/jdk.internal.ref=ALL-UNNAMED --add-opens=java.base/java.lang=ALL-UNNAMED --add-opens=java.base/java.nio=ALL-UNNAMED --add-opens=java.base/sun.nio.ch=ALL-UNNAMED --add-opens=java.management/sun.management=ALL-UNNAMED --add-opens=java.base/sun.net.www.protocol.jrt=ALL-UNNAMED -Xbootclasspath/a:${com.sun.aas.installRoot}/lib/grizzly-npn-api.jar --add-exports=java.base/sun.net.www=ALL-UNNAMED --add-exports=java.base/sun.security.util=ALL-UNNAMED --add-opens=java.base/java.lang.invoke=ALL-UNNAMED --add-opens=java.desktop/java.beans=ALL-UNNAMED --add-exports=jdk.naming.dns/com.sun.jndi.dns=ALL-UNNAMED --add-opens=java.base/sun.net.www.protocol.jar=ALL-UNNAMED
-```
+----

--- a/docs/modules/ROOT/pages/Technical Documentation/Payara Server Documentation/Payara Server Embedded.adoc
+++ b/docs/modules/ROOT/pages/Technical Documentation/Payara Server Documentation/Payara Server Embedded.adoc
@@ -5,10 +5,12 @@ Payara Embedded allows you to embed Payara Server into a Java application, there
 
 [[payara-embedded-distributions]]
 == Distributions
-Payara Embedded has two distributions, `payara-embedded-all` and `payara-embedded-web`, functionally these are the same as their standalone counterparts, Payara Server and Payara Server Web respectively.
+
+Payara Embedded has two distribution variants, `payara-embedded-all` and `payara-embedded-web`, functionally these are the same as their standalone counterparts, Payara Server Full Profile and Payara Server Web Profile respectively.
 
 [[using-payara-embedded]]
 == Getting Started
+
 To use Payara Embedded within your project, you first need to add one of the distributions as a dependency:
 
 Payara Embedded All::
@@ -35,6 +37,7 @@ Payara Embedded Web::
 
 [[payara-embedded-example]]
 === Example
+
 After adding a Payara Embedded distribution as a dependency, you can begin using Payara Embedded in your application and project. For example, the following code will create and start an embedded Payara server, with the HTTP and HTTPS listener set to ports 9080 and 9845 respectively with the application `clusterjsp.war` deployed:
 
 [source,java]
@@ -50,8 +53,6 @@ import org.glassfish.embeddable.GlassFishRuntime;
 /**
  * Basic Example showing how to programmatically create, edit, start and deploy to
  * an embedded Payara Server.
- *
- * @author James Hillyard <james.hillyard@payara.fish>
  */
 public class Main {
 
@@ -92,12 +93,19 @@ While performing integration testing, you may need to deploy the application to 
 
 Integration testing can be done easier and more consistently with Payara Embedded, you can start Payara up as the beginning of the test, verify the functionality and then use a clean instance for each test, therefore eliminating the possibility of an unexpected state in the environment.
 
-Starting Payara Embedded for testing can also be done using the Arquillian connector. In that case, the setup and teardown of Payara is managed for you. Read about the xref:Technical Documentation/Ecosystem/Connector Suites/Arquillian Containers/Payara Server Embedded.adoc[Payara Arquillian Connector]
+Starting Payara Embedded for testing can also be done using the Arquillian connector. In that case, the setup and teardown of Payara is managed for you.
 
+[[jdk-17-considerations]]
 == JDK 17 Considerations
+
 When running Payara Embedded on JDK 17, you must update your client side run configuration with all the necessary opens and exports for Payara to work as expected. The following JVM options should be added within your run configuration:
 
 [source, shell]
 ----
 --add-opens=java.base/jdk.internal.loader=ALL-UNNAMED --add-opens=jdk.management/com.sun.management.internal=ALL-UNNAMED --add-exports=java.base/jdk.internal.ref=ALL-UNNAMED --add-opens=java.base/java.lang=ALL-UNNAMED --add-opens=java.base/java.nio=ALL-UNNAMED --add-opens=java.base/sun.nio.ch=ALL-UNNAMED --add-opens=java.management/sun.management=ALL-UNNAMED --add-opens=java.base/sun.net.www.protocol.jrt=ALL-UNNAMED -Xbootclasspath/a:${com.sun.aas.installRoot}/lib/grizzly-npn-api.jar --add-exports=java.base/sun.net.www=ALL-UNNAMED --add-exports=java.base/sun.security.util=ALL-UNNAMED --add-opens=java.base/java.lang.invoke=ALL-UNNAMED --add-opens=java.desktop/java.beans=ALL-UNNAMED --add-exports=jdk.naming.dns/com.sun.jndi.dns=ALL-UNNAMED --add-opens=java.base/sun.net.www.protocol.jar=ALL-UNNAMED
 ----
+
+[[see-also]]
+== See Also
+
+xref:Technical Documentation/Ecosystem/Connector Suites/Arquillian Containers/Payara Server Embedded.adoc[Payara Arquillian Connector]

--- a/docs/modules/ROOT/pages/Technical Documentation/Payara Server Documentation/Payara Server Embedded.adoc
+++ b/docs/modules/ROOT/pages/Technical Documentation/Payara Server Documentation/Payara Server Embedded.adoc
@@ -84,8 +84,6 @@ Where the installation of Payara Server and the deployment of the applications c
 
 Instead of having the three steps, installing Payara Server, configuring the environment, and deploying the application, you can do all those steps within the application containing Payara Embedded. You only need to start the application and the system is ready to respond to user requests.
 
-TIP: Unless you require specifications only in the Jakarta Full Profile, like SOAP support, you should use Payara Micro instead.
-
 [[integration-testing]]
 === Integration Testing
 

--- a/docs/modules/ROOT/pages/Technical Documentation/Payara Server Documentation/Payara Server Embedded.adoc
+++ b/docs/modules/ROOT/pages/Technical Documentation/Payara Server Documentation/Payara Server Embedded.adoc
@@ -1,0 +1,100 @@
+[[payara-server-embedded]]
+= Payara Server Embedded
+
+Payara Embedded allows you to embed Payara Server into a Java application, therefore allowing you to start and control Payara programmatically.
+
+[[payara-embedded-distributions]]
+== Distributions
+Payara Embedded has two distributions, `payara-embedded-all` and `payara-embedded-web`, functionally these are the same as their standalone counterparts, Payara Server and Payara Server Web respectively.
+
+[[using-payara-embedded]]
+== Getting Started
+To use Payara Embedded within your project, you first need to add one of the distributions as a dependency:
+
+Payara Embedded All::
+[source,xml]
+```
+<dependency>
+    <groupId>fish.payara.extras</groupId>
+    <artifactId>payara-embedded-all</artifactId>
+    <version>{page-version}</version>
+    <type>jar</type>
+</dependency>
+```
+
+Payara Embedded Web::
+[source,xml]
+```
+<dependency>
+    <groupId>fish.payara.extras</groupId>
+    <artifactId>payara-embedded-web</artifactId>
+    <version>{page-version}</version>
+    <type>jar</type>
+</dependency>
+```
+
+[[payara-embedded-example]]
+=== Example
+After adding a Payara Embedded distribution as a dependency, you can begin using Payara Embedded in your application and project. For example, the following code will create and start an embedded Payara server, with the HTTP and HTTPS listener set to ports 9080 and 9845 respectively with the application `clusterjsp.war` deployed:
+
+[source,java]
+```
+import java.io.File;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import org.glassfish.embeddable.GlassFish;
+import org.glassfish.embeddable.GlassFishException;
+import org.glassfish.embeddable.GlassFishProperties;
+import org.glassfish.embeddable.GlassFishRuntime;
+
+/**
+ * Basic Example showing how to programmatically create, edit, start and deploy to
+ * an embedded Payara Server.
+ *
+ * @author James Hillyard <james.hillyard@payara.fish>
+ */
+public class Main {
+
+    public static void main(String[] args) {
+        try {
+            GlassFishRuntime runtime = GlassFishRuntime.bootstrap();
+            GlassFishProperties glassfishProperties = new GlassFishProperties();
+            glassfishProperties.setPort("http-listener", 9080);
+            glassfishProperties.setPort("https-listener", 9845);
+            GlassFish glassfish = runtime.newGlassFish(glassfishProperties);
+            glassfish.start();
+            glassfish.getDeployer().deploy(new File("opt/applications/clusterjsp.war"));
+        } catch (GlassFishException ex) {
+            Logger.getLogger(Main.class.getName()).log(Level.SEVERE, null, ex);
+        }
+    }
+}
+```
+
+[[payara-embedded-usecases]]
+== Payara Embedded Usecases
+Overview of some expected usecases of Payara Embedded.
+
+[[bundle-application]]
+=== Bundle your Application
+Where the installation of Payara Server and the deployment of the applications can't be done on a cetral infrastructure, you may opt to use Payara Embedded. In this case, you can bundle Payara Server with the application within a single application, which makes it easier for installing it.
+
+Instead of having the three steps, installing Payara Server, configuring the environment, and deploying the application, you can do all those steps within the application containing Payara Embedded. You only need to start the application and the system is ready to respond to user requests.
+
+TIP: Unless you require specifications only in the Jakarta Full Profile, like SOAP support, you should use Payara Micro instead.
+
+[[integration-testing]]
+=== Integration Testing
+While performing integration testing, you may need to deploy the application to Payara in order to verify the behaviour of the code you have written. While you could use a standalone installation of Payara Server, cleanup is not always done correctly and can cause other tests to behave incorrectly.
+
+Integration testing can be done easier and more consistently with Payara Embedded, you can start Payara up as the beginning of the test, verify the functionality and then use a clean instance for each test, therefore eliminating the possibility of an unexpected state in the environment.
+
+Starting Payara Embedded for testing can also be done using the Arquillian connector. In that case, the setup and teardown of Payara is managed for you. Read about the xref:Technical Documentation/Ecosystem/Connector Suites/Arquillian Containers/Payara Server Embedded.adoc[Payara Arquillian Connector]
+
+== JDK 17 Considerations
+When running Payara Embedded on JDK 17, you must update your client side run configuration with all the necessary opens and exports for Payara to work as expected. The following JVM options should be added within your run configuration:
+
+[source,text]
+```
+--add-opens=java.base/jdk.internal.loader=ALL-UNNAMED --add-opens=jdk.management/com.sun.management.internal=ALL-UNNAMED --add-exports=java.base/jdk.internal.ref=ALL-UNNAMED --add-opens=java.base/java.lang=ALL-UNNAMED --add-opens=java.base/java.nio=ALL-UNNAMED --add-opens=java.base/sun.nio.ch=ALL-UNNAMED --add-opens=java.management/sun.management=ALL-UNNAMED --add-opens=java.base/sun.net.www.protocol.jrt=ALL-UNNAMED -Xbootclasspath/a:${com.sun.aas.installRoot}/lib/grizzly-npn-api.jar --add-exports=java.base/sun.net.www=ALL-UNNAMED --add-exports=java.base/sun.security.util=ALL-UNNAMED --add-opens=java.base/java.lang.invoke=ALL-UNNAMED --add-opens=java.desktop/java.beans=ALL-UNNAMED --add-exports=jdk.naming.dns/com.sun.jndi.dns=ALL-UNNAMED --add-opens=java.base/sun.net.www.protocol.jar=ALL-UNNAMED
+```

--- a/enterprise/docs/modules/ROOT/nav.adoc
+++ b/enterprise/docs/modules/ROOT/nav.adoc
@@ -115,6 +115,7 @@
 ***** xref:Technical Documentation/Payara Micro Documentation/Payara Micro Configuration and Management/Micro Management/Stopping and Starting Instances/Stopping Instance.adoc[Stopping Instance]
 * Payara Server Documentation
 ** xref:Technical Documentation/Payara Server Documentation/Overview.adoc[Overview]
+** xref:Technical Documentation/Payara Server Documentation/Payara Server Embedded.adoc[Payara Server Embedded]
 ** xref:Technical Documentation/Payara Server Documentation/Payara Server Docker Image.adoc[Payara Server Docker Image]
 ** Upgrade Payara
 *** xref:Technical Documentation/Payara Server Documentation/Upgrade Payara/Overview.adoc[Overview]


### PR DESCRIPTION
Documents the JDK 17 Considerations for Payara Embedded. Currently there is no documentation page dedicated to Payara Embedded so I had to document that too.

Put the page at the same level as the Payara Docker Images - If you feel there is a better place for it let me know