### PR TITLE
Update Documentation with Reference to Opentracing 0.33.0

### DIFF
--- a/community/docs/modules/ROOT/nav.adoc
+++ b/community/docs/modules/ROOT/nav.adoc
@@ -1,266 +1,266 @@
 
 .General Info
 * xref:General Info/Overview.adoc[Overview]
-* xref:General Info/Build Instructions.adoc[Build Instructions]
-* xref:General Info/Contributing To Payara.adoc[Contributing To Payara]
 * xref:General Info/Getting Started.adoc[Getting Started]
+* xref:General Info/Build Instructions.adoc[Build Instructions]
 * xref:General Info/Supported Platforms.adoc[Supported Platforms]
+* xref:General Info/Contributing To Payara.adoc[Contributing To Payara]
 
 .Technical Documentation
-* Ecosystem
-** xref:Technical Documentation/Ecosystem/Overview.adoc[Overview]
-** Connector Suites
-*** xref:Technical Documentation/Ecosystem/Connector Suites/Security Connectors.adoc[Security Connectors]
-*** Arquillian Containers
-**** xref:Technical Documentation/Ecosystem/Connector Suites/Arquillian Containers/Overview.adoc[Overview]
-**** xref:Technical Documentation/Ecosystem/Connector Suites/Arquillian Containers/Payara Micro Managed.adoc[Payara Micro Managed]
-**** xref:Technical Documentation/Ecosystem/Connector Suites/Arquillian Containers/Payara Server Embedded.adoc[Payara Server Embedded]
-**** xref:Technical Documentation/Ecosystem/Connector Suites/Arquillian Containers/Payara Server Managed.adoc[Payara Server Managed]
-**** xref:Technical Documentation/Ecosystem/Connector Suites/Arquillian Containers/Payara Server Remote.adoc[Payara Server Remote]
-*** Cloud Connectors
-**** xref:Technical Documentation/Ecosystem/Connector Suites/Cloud Connectors/Amazon SQS.adoc[Amazon SQS]
-**** xref:Technical Documentation/Ecosystem/Connector Suites/Cloud Connectors/Apache Kafka.adoc[Apache Kafka]
-**** xref:Technical Documentation/Ecosystem/Connector Suites/Cloud Connectors/Azure SB.adoc[Azure SB]
-**** xref:Technical Documentation/Ecosystem/Connector Suites/Cloud Connectors/MQTT.adoc[MQTT]
-**** xref:Technical Documentation/Ecosystem/Connector Suites/Cloud Connectors/Overview.adoc[Overview]
-** IDE Integration
-*** Eclipse Plugin
-**** xref:Technical Documentation/Ecosystem/IDE Integration/Eclipse Plugin/Overview.adoc[Overview]
-**** xref:Technical Documentation/Ecosystem/IDE Integration/Eclipse Plugin/Payara Micro.adoc[Payara Micro]
-**** xref:Technical Documentation/Ecosystem/IDE Integration/Eclipse Plugin/Payara Server.adoc[Payara Server]
-*** Intellij Plugin
-**** xref:Technical Documentation/Ecosystem/IDE Integration/Intellij Plugin/Overview.adoc[Overview]
-**** xref:Technical Documentation/Ecosystem/IDE Integration/Intellij Plugin/Payara Micro.adoc[Payara Micro]
-**** xref:Technical Documentation/Ecosystem/IDE Integration/Intellij Plugin/Payara Server.adoc[Payara Server]
-*** NetBeans Plugin
-**** xref:Technical Documentation/Ecosystem/IDE Integration/NetBeans Plugin/Overview.adoc[Overview]
-**** xref:Technical Documentation/Ecosystem/IDE Integration/NetBeans Plugin/Payara Micro.adoc[Payara Micro]
-**** xref:Technical Documentation/Ecosystem/IDE Integration/NetBeans Plugin/Payara Server.adoc[Payara Server]
-*** VSCode Extension
-**** xref:Technical Documentation/Ecosystem/IDE Integration/VSCode Extension/Overview.adoc[Overview]
-**** xref:Technical Documentation/Ecosystem/IDE Integration/VSCode Extension/Payara Micro.adoc[Payara Micro]
-**** xref:Technical Documentation/Ecosystem/IDE Integration/VSCode Extension/Payara Server.adoc[Payara Server]
-** Miscellaneous
-*** xref:Technical Documentation/Ecosystem/Miscellaneous/JAX-RS Extension.adoc[JAX-RS Extension]
-** Project Management Tools
-*** xref:Technical Documentation/Ecosystem/Project Management Tools/Gradle Plugin.adoc[Gradle Plugin]
-*** xref:Technical Documentation/Ecosystem/Project Management Tools/Maven Archetype.adoc[Maven Archetype]
-*** xref:Technical Documentation/Ecosystem/Project Management Tools/Maven Bom.adoc[Maven Bom]
-*** xref:Technical Documentation/Ecosystem/Project Management Tools/Maven Plugin.adoc[Maven Plugin]
-* MicroProfile
-** xref:Technical Documentation/MicroProfile/Overview.adoc[Overview]
-** xref:Technical Documentation/MicroProfile/JWT.adoc[JWT]
-** xref:Technical Documentation/MicroProfile/Rest Client.adoc[Rest Client]
-** xref:Technical Documentation/MicroProfile/Fault Tolerance.adoc[Fault Tolerance]
-** xref:Technical Documentation/MicroProfile/HealthCheck.adoc[HealthCheck]
-** xref:Technical Documentation/MicroProfile/OpenAPI.adoc[OpenAPI]
-** xref:Technical Documentation/MicroProfile/Opentracing.adoc[Opentracing]
-** Config
-*** xref:Technical Documentation/MicroProfile/Config/Overview.adoc[Overview]
-*** xref:Technical Documentation/MicroProfile/Config/Directory.adoc[Directory]
-*** xref:Technical Documentation/MicroProfile/Config/JDBC.adoc[JDBC]
-*** xref:Technical Documentation/MicroProfile/Config/LDAP.adoc[LDAP]
-*** Cloud
-**** xref:Technical Documentation/MicroProfile/Config/Cloud/Overview.adoc[Overview]
-**** xref:Technical Documentation/MicroProfile/Config/Cloud/AWS.adoc[AWS]
-**** xref:Technical Documentation/MicroProfile/Config/Cloud/DynamoDB.adoc[DynamoDB]
-**** xref:Technical Documentation/MicroProfile/Config/Cloud/GCP.adoc[GCP]
-**** xref:Technical Documentation/MicroProfile/Config/Cloud/Hashicorp.adoc[Hashicorp]
-**** xref:Technical Documentation/MicroProfile/Config/Cloud/Azure.adoc[Azure]
-** Metrics
-*** xref:Technical Documentation/MicroProfile/Metrics/Metrics Configuration.adoc[Metrics Configuration]
-*** xref:Technical Documentation/MicroProfile/Metrics/Metrics Rest Endpoint.adoc[Metrics Rest Endpoint]
-*** xref:Technical Documentation/MicroProfile/Metrics/Vendor Metrics.adoc[Vendor Metrics]
 * Payara Micro Documentation
 ** xref:Technical Documentation/Payara Micro Documentation/Overview.adoc[Overview]
 ** xref:Technical Documentation/Payara Micro Documentation/Maven Support.adoc[Maven Support]
 ** xref:Technical Documentation/Payara Micro Documentation/Payara Micro Docker Image.adoc[Payara Micro Docker Image]
-** API
-*** xref:Technical Documentation/Payara Micro Documentation/API/JCache in Payara Micro.adoc[JCache in Payara Micro]
-*** Payara Micro API
-**** xref:Technical Documentation/Payara Micro Documentation/API/Payara Micro API/Overview.adoc[Overview]
-**** xref:Technical Documentation/Payara Micro Documentation/API/Payara Micro API/Using the Payara Micro API.adoc[Using the Payara Micro API]
 ** Extensions
-*** xref:Technical Documentation/Payara Micro Documentation/Extensions/JCA Support.adoc[JCA Support]
 *** xref:Technical Documentation/Payara Micro Documentation/Extensions/Persistent EJB Timers.adoc[Persistent EJB Timers]
 *** xref:Technical Documentation/Payara Micro Documentation/Extensions/Remote CDI Events.adoc[Remote CDI Events]
 *** xref:Technical Documentation/Payara Micro Documentation/Extensions/Running Callable Objects.adoc[Running Callable Objects]
+*** xref:Technical Documentation/Payara Micro Documentation/Extensions/JCA Support.adoc[JCA Support]
+** Payara Micro Configuration and Management
+*** Micro Management
+**** xref:Technical Documentation/Payara Micro Documentation/Payara Micro Configuration and Management/Micro Management/Configuring An Instance.adoc[Configuring An Instance]
+**** xref:Technical Documentation/Payara Micro Documentation/Payara Micro Configuration and Management/Micro Management/Clustering.adoc[Clustering]
+**** xref:Technical Documentation/Payara Micro Documentation/Payara Micro Configuration and Management/Micro Management/HTTP(S) Auto-Binding.adoc[HTTP(S) Auto-Binding]
+**** Jar Structure and Configuration
+***** xref:Technical Documentation/Payara Micro Documentation/Payara Micro Configuration and Management/Micro Management/Jar Structure and Configuration/Payara Micro Jar Structure.adoc[Payara Micro Jar Structure]
+***** xref:Technical Documentation/Payara Micro Documentation/Payara Micro Configuration and Management/Micro Management/Jar Structure and Configuration/Root Directory.adoc[Root Directory]
+***** xref:Technical Documentation/Payara Micro Documentation/Payara Micro Configuration and Management/Micro Management/Jar Structure and Configuration/Adding Jars.adoc[Adding Jars]
+**** Stopping and Starting Instances
+***** xref:Technical Documentation/Payara Micro Documentation/Payara Micro Configuration and Management/Micro Management/Stopping and Starting Instances/Stopping Instance.adoc[Stopping Instance]
+***** xref:Technical Documentation/Payara Micro Documentation/Payara Micro Configuration and Management/Micro Management/Stopping and Starting Instances/Starting Instance.adoc[Starting Instance]
+**** Deploying Applications
+***** xref:Technical Documentation/Payara Micro Documentation/Payara Micro Configuration and Management/Micro Management/Deploying Applications/Deploy Applications Programmatically.adoc[Deploy Applications Programmatically]
+***** xref:Technical Documentation/Payara Micro Documentation/Payara Micro Configuration and Management/Micro Management/Deploying Applications/Deploy Applications.adoc[Deploy Applications]
+**** Command Line Options
+***** xref:Technical Documentation/Payara Micro Documentation/Payara Micro Configuration and Management/Micro Management/Command Line Options/Disable Phone Home.adoc[Disable Phone Home]
+***** xref:Technical Documentation/Payara Micro Documentation/Payara Micro Configuration and Management/Micro Management/Command Line Options/Command Line Options.adoc[Command Line Options]
+**** Asadmin Commands
+***** xref:Technical Documentation/Payara Micro Documentation/Payara Micro Configuration and Management/Micro Management/Asadmin Commands/Send Asadmin Commands from Admin Console.adoc[Send Asadmin Commands from Admin Console]
+***** xref:Technical Documentation/Payara Micro Documentation/Payara Micro Configuration and Management/Micro Management/Asadmin Commands/Pre and Post Boot Commands.adoc[Pre and Post Boot Commands]
+*** Database Management
+**** xref:Technical Documentation/Payara Micro Documentation/Payara Micro Configuration and Management/Database Management/Slow SQL Logger.adoc[Slow SQL Logger]
+**** xref:Technical Documentation/Payara Micro Documentation/Payara Micro Configuration and Management/Database Management/Log JDBC Calls.adoc[Log JDBC Calls]
+**** xref:Technical Documentation/Payara Micro Documentation/Payara Micro Configuration and Management/Database Management/SQL Trace Listeners.adoc[SQL Trace Listeners]
 ** Logging and Monitoring
 *** xref:Technical Documentation/Payara Micro Documentation/Logging and Monitoring/Request Tracing.adoc[Request Tracing]
 *** Logging
 **** xref:Technical Documentation/Payara Micro Documentation/Logging and Monitoring/Logging/Config Access Log.adoc[Config Access Log]
 **** xref:Technical Documentation/Payara Micro Documentation/Logging and Monitoring/Logging/Logging to File.adoc[Logging to File]
-** Payara Micro Configuration and Management
-*** Database Management
-**** xref:Technical Documentation/Payara Micro Documentation/Payara Micro Configuration and Management/Database Management/Log JDBC Calls.adoc[Log JDBC Calls]
-**** xref:Technical Documentation/Payara Micro Documentation/Payara Micro Configuration and Management/Database Management/Slow SQL Logger.adoc[Slow SQL Logger]
-**** xref:Technical Documentation/Payara Micro Documentation/Payara Micro Configuration and Management/Database Management/SQL Trace Listeners.adoc[SQL Trace Listeners]
-*** Micro Management
-**** xref:Technical Documentation/Payara Micro Documentation/Payara Micro Configuration and Management/Micro Management/Clustering.adoc[Clustering]
-**** xref:Technical Documentation/Payara Micro Documentation/Payara Micro Configuration and Management/Micro Management/Configuring An Instance.adoc[Configuring An Instance]
-**** xref:Technical Documentation/Payara Micro Documentation/Payara Micro Configuration and Management/Micro Management/HTTP(S) Auto-Binding.adoc[HTTP(S) Auto-Binding]
-**** Asadmin Commands
-***** xref:Technical Documentation/Payara Micro Documentation/Payara Micro Configuration and Management/Micro Management/Asadmin Commands/Pre and Post Boot Commands.adoc[Pre and Post Boot Commands]
-***** xref:Technical Documentation/Payara Micro Documentation/Payara Micro Configuration and Management/Micro Management/Asadmin Commands/Send Asadmin Commands from Admin Console.adoc[Send Asadmin Commands from Admin Console]
-**** Command Line Options
-***** xref:Technical Documentation/Payara Micro Documentation/Payara Micro Configuration and Management/Micro Management/Command Line Options/Command Line Options.adoc[Command Line Options]
-***** xref:Technical Documentation/Payara Micro Documentation/Payara Micro Configuration and Management/Micro Management/Command Line Options/Disable Phone Home.adoc[Disable Phone Home]
-**** Deploying Applications
-***** xref:Technical Documentation/Payara Micro Documentation/Payara Micro Configuration and Management/Micro Management/Deploying Applications/Deploy Applications Programmatically.adoc[Deploy Applications Programmatically]
-***** xref:Technical Documentation/Payara Micro Documentation/Payara Micro Configuration and Management/Micro Management/Deploying Applications/Deploy Applications.adoc[Deploy Applications]
-**** Jar Structure and Configuration
-***** xref:Technical Documentation/Payara Micro Documentation/Payara Micro Configuration and Management/Micro Management/Jar Structure and Configuration/Adding Jars.adoc[Adding Jars]
-***** xref:Technical Documentation/Payara Micro Documentation/Payara Micro Configuration and Management/Micro Management/Jar Structure and Configuration/Payara Micro Jar Structure.adoc[Payara Micro Jar Structure]
-***** xref:Technical Documentation/Payara Micro Documentation/Payara Micro Configuration and Management/Micro Management/Jar Structure and Configuration/Root Directory.adoc[Root Directory]
-**** Stopping and Starting Instances
-***** xref:Technical Documentation/Payara Micro Documentation/Payara Micro Configuration and Management/Micro Management/Stopping and Starting Instances/Starting Instance.adoc[Starting Instance]
-***** xref:Technical Documentation/Payara Micro Documentation/Payara Micro Configuration and Management/Micro Management/Stopping and Starting Instances/Stopping Instance.adoc[Stopping Instance]
+** API
+*** xref:Technical Documentation/Payara Micro Documentation/API/JCache in Payara Micro.adoc[JCache in Payara Micro]
+*** Payara Micro API
+**** xref:Technical Documentation/Payara Micro Documentation/API/Payara Micro API/Overview.adoc[Overview]
+**** xref:Technical Documentation/Payara Micro Documentation/API/Payara Micro API/Using the Payara Micro API.adoc[Using the Payara Micro API]
 * Payara Server Documentation
 ** xref:Technical Documentation/Payara Server Documentation/Overview.adoc[Overview]
 ** xref:Technical Documentation/Payara Server Documentation/Payara Server Embedded.adoc[Payara Server Embedded]
 ** xref:Technical Documentation/Payara Server Documentation/Payara Server Docker Image.adoc[Payara Server Docker Image]
 ** Upgrade Payara
 *** xref:Technical Documentation/Payara Server Documentation/Upgrade Payara/Overview.adoc[Overview]
-*** xref:Technical Documentation/Payara Server Documentation/Upgrade Payara/Backup and Restore Method.adoc[Backup and Restore Method]
 *** xref:Technical Documentation/Payara Server Documentation/Upgrade Payara/Domain and Node Directories Method.adoc[Domain and Node Directories Method]
-** Deployment Groups
-*** xref:Technical Documentation/Payara Server Documentation/Deployment Groups/Overview.adoc[Overview]
-*** xref:Technical Documentation/Payara Server Documentation/Deployment Groups/Asadmin Commands.adoc[Asadmin Commands]
-*** xref:Technical Documentation/Payara Server Documentation/Deployment Groups/Timers.adoc[Timers]
-** Development Debugging And Assistance Tools
-*** xref:Technical Documentation/Payara Server Documentation/Development Debugging And Assistance Tools/CDI.adoc[CDI]
+*** xref:Technical Documentation/Payara Server Documentation/Upgrade Payara/Backup and Restore Method.adoc[Backup and Restore Method]
 ** Extensions
 *** xref:Technical Documentation/Payara Server Documentation/Extensions/Overview.adoc[Overview]
-*** Notifiers
-**** xref:Technical Documentation/Payara Server Documentation/Extensions/Notifiers/Overview.adoc[Overview]
-**** xref:Technical Documentation/Payara Server Documentation/Extensions/Notifiers/Custom Notifiers.adoc[Custom Notifiers]
-**** xref:Technical Documentation/Payara Server Documentation/Extensions/Notifiers/Datadog.adoc[Datadog]
-**** xref:Technical Documentation/Payara Server Documentation/Extensions/Notifiers/Discord.adoc[Discord]
-**** xref:Technical Documentation/Payara Server Documentation/Extensions/Notifiers/Email.adoc[Email]
-**** xref:Technical Documentation/Payara Server Documentation/Extensions/Notifiers/MS Teams.adoc[MS Teams]
-**** xref:Technical Documentation/Payara Server Documentation/Extensions/Notifiers/New Relic.adoc[New Relic]
-**** xref:Technical Documentation/Payara Server Documentation/Extensions/Notifiers/Slack.adoc[Slack]
-**** xref:Technical Documentation/Payara Server Documentation/Extensions/Notifiers/SNMP.adoc[SNMP]
-**** xref:Technical Documentation/Payara Server Documentation/Extensions/Notifiers/XMPP.adoc[XMPP]
 *** AutoScale Groups
 **** xref:Technical Documentation/Payara Server Documentation/Extensions/AutoScale Groups/Overview.adoc[Overview]
-**** xref:Technical Documentation/Payara Server Documentation/Extensions/AutoScale Groups/Create AutoScale Group.adoc[Create AutoScale Group]
 **** xref:Technical Documentation/Payara Server Documentation/Extensions/AutoScale Groups/Nodes Scaling Group.adoc[Nodes Scaling Group]
+**** xref:Technical Documentation/Payara Server Documentation/Extensions/AutoScale Groups/Create AutoScale Group.adoc[Create AutoScale Group]
+*** Notifiers
+**** xref:Technical Documentation/Payara Server Documentation/Extensions/Notifiers/Overview.adoc[Overview]
+**** xref:Technical Documentation/Payara Server Documentation/Extensions/Notifiers/Discord.adoc[Discord]
+**** xref:Technical Documentation/Payara Server Documentation/Extensions/Notifiers/Custom Notifiers.adoc[Custom Notifiers]
+**** xref:Technical Documentation/Payara Server Documentation/Extensions/Notifiers/Slack.adoc[Slack]
+**** xref:Technical Documentation/Payara Server Documentation/Extensions/Notifiers/Email.adoc[Email]
+**** xref:Technical Documentation/Payara Server Documentation/Extensions/Notifiers/SNMP.adoc[SNMP]
+**** xref:Technical Documentation/Payara Server Documentation/Extensions/Notifiers/New Relic.adoc[New Relic]
+**** xref:Technical Documentation/Payara Server Documentation/Extensions/Notifiers/XMPP.adoc[XMPP]
+**** xref:Technical Documentation/Payara Server Documentation/Extensions/Notifiers/Datadog.adoc[Datadog]
+**** xref:Technical Documentation/Payara Server Documentation/Extensions/Notifiers/MS Teams.adoc[MS Teams]
 *** gRPC Support
 **** xref:Technical Documentation/Payara Server Documentation/Extensions/gRPC Support/Overview.adoc[Overview]
 **** xref:Technical Documentation/Payara Server Documentation/Extensions/gRPC Support/Usage.adoc[Usage]
 **** xref:Technical Documentation/Payara Server Documentation/Extensions/gRPC Support/Installation.adoc[Installation]
+** Development Debugging And Assistance Tools
+*** xref:Technical Documentation/Payara Server Documentation/Development Debugging And Assistance Tools/CDI.adoc[CDI]
+** Server Configuration And Management
+*** JDBC Resource Management
+**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/JDBC Resource Management/JDBC.adoc[JDBC]
+**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/JDBC Resource Management/SQL.adoc[SQL]
+*** Admin Console Enhancements
+**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Admin Console Enhancements/Overview.adoc[Overview]
+**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Admin Console Enhancements/Auditing Service.adoc[Auditing Service]
+**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Admin Console Enhancements/Environment Warning.adoc[Environment Warning]
+**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Admin Console Enhancements/Asadmin Recorder.adoc[Asadmin Recorder]
+*** Security Configuration
+**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Security Configuration/Overview.adoc[Overview]
+**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Security Configuration/Multiple Mechanism in EAR.adoc[Multiple Mechanism in EAR]
+**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Security Configuration/JACC.adoc[JACC]
+**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Security Configuration/JCE Provider Support.adoc[JCE Provider Support]
+**** Client Certificates
+***** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Security Configuration/Client Certificates/Custom Validators.adoc[Custom Validators]
+***** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Security Configuration/Client Certificates/Advanced Groups Configuration.adoc[Advanced Groups Configuration]
+***** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Security Configuration/Client Certificates/Advanced Principal Name Configuration.adoc[Advanced Principal Name Configuration]
+*** Thread Pools
+**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Thread Pools/EJB Thread Pool.adoc[EJB Thread Pool]
+**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Thread Pools/Default Thread Pool Size.adoc[Default Thread Pool Size]
+*** Classloading
+**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Classloading/Overview.adoc[Overview]
+**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Classloading/Standard Classloading.adoc[Standard Classloading]
+**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Classloading/Enhanced Classloading.adoc[Enhanced Classloading]
+*** Application Deployment
+**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Application Deployment/Overview.adoc[Overview]
+**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Application Deployment/Descriptor Elements.adoc[Descriptor Elements]
+**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Application Deployment/Deployment Descriptors.adoc[Deployment Descriptors]
+**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Application Deployment/Concurrent CDI Bean Loading.adoc[Concurrent CDI Bean Loading]
+*** Docker Host Support
+**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Docker Host Support/Docker Nodes.adoc[Docker Nodes]
+**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Docker Host Support/Docker Instances.adoc[Docker Instances]
+*** Configuration Options
+**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Configuration Options/Password Aliases.adoc[Password Aliases]
+**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Configuration Options/Phone Home.adoc[Phone Home]
+**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Configuration Options/JVM Options.adoc[JVM Options]
+**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Configuration Options/SSL Certificates.adoc[SSL Certificates]
+**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Configuration Options/System Properties.adoc[System Properties]
+**** Variable Substitution
+***** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Configuration Options/Variable Substitution/Usage of Variables.adoc[Usage of Variables]
+***** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Configuration Options/Variable Substitution/Types of Variables.adoc[Types of Variables]
+*** HTTP Service
+**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/HTTP Service/Overview.adoc[Overview]
+**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/HTTP Service/Protocols.adoc[Protocols]
+**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/HTTP Service/Virtual Servers.adoc[Virtual Servers]
+**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/HTTP Service/Network Listeners.adoc[Network Listeners]
+*** Asadmin Commands
+**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Asadmin Commands/Server Management Asadmin Commands.adoc[Server Management Asadmin Commands]
+**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Asadmin Commands/Multimode Event Designators Support.adoc[Multimode Event Designators Support]
+**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Asadmin Commands/Auto Naming.adoc[Auto Naming]
+**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Asadmin Commands/Print Certificate Data.adoc[Print Certificate Data]
+*** Domain Data Grid And Hazelcast
+**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Domain Data Grid And Hazelcast/Overview.adoc[Overview]
+**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Domain Data Grid And Hazelcast/Datagrid in Applications.adoc[Datagrid in Applications]
+**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Domain Data Grid And Hazelcast/Configuration.adoc[Configuration]
+**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Domain Data Grid And Hazelcast/Encryption.adoc[Encryption]
+**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Domain Data Grid And Hazelcast/Viewing Members.adoc[Viewing Members]
+**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Domain Data Grid And Hazelcast/Discovery.adoc[Discovery]
+** Deployment Groups
+*** xref:Technical Documentation/Payara Server Documentation/Deployment Groups/Overview.adoc[Overview]
+*** xref:Technical Documentation/Payara Server Documentation/Deployment Groups/Asadmin Commands.adoc[Asadmin Commands]
+*** xref:Technical Documentation/Payara Server Documentation/Deployment Groups/Timers.adoc[Timers]
 ** Jakarta EE API
-*** xref:Technical Documentation/Payara Server Documentation/Jakarta EE API/JavaMail API.adoc[JavaMail API]
-*** xref:Technical Documentation/Payara Server Documentation/Jakarta EE API/JAX-WS Enhancements.adoc[JAX-WS Enhancements]
 *** xref:Technical Documentation/Payara Server Documentation/Jakarta EE API/JCache API.adoc[JCache API]
-*** Enterprise Java Beans (EJB)
-**** xref:Technical Documentation/Payara Server Documentation/Jakarta EE API/Enterprise Java Beans (EJB)/Overview.adoc[Overview]
-**** xref:Technical Documentation/Payara Server Documentation/Jakarta EE API/Enterprise Java Beans (EJB)/JDK 17 Support.adoc[JDK 17 Support]
-**** xref:Technical Documentation/Payara Server Documentation/Jakarta EE API/Enterprise Java Beans (EJB)/Tracing Remote EJBs.adoc[Tracing Remote EJBs]
+*** xref:Technical Documentation/Payara Server Documentation/Jakarta EE API/JAX-WS Enhancements.adoc[JAX-WS Enhancements]
+*** xref:Technical Documentation/Payara Server Documentation/Jakarta EE API/JavaMail API.adoc[JavaMail API]
 *** JAX-RS
 **** xref:Technical Documentation/Payara Server Documentation/Jakarta EE API/JAX-RS/CDI With JAX-RS.adoc[CDI With JAX-RS]
-*** JBatch API
-**** xref:Technical Documentation/Payara Server Documentation/Jakarta EE API/JBatch API/Overview.adoc[Overview]
-**** xref:Technical Documentation/Payara Server Documentation/Jakarta EE API/JBatch API/Database Support.adoc[Database Support]
-**** xref:Technical Documentation/Payara Server Documentation/Jakarta EE API/JBatch API/Improved Asadmin CLI.adoc[Improved Asadmin CLI]
-**** xref:Technical Documentation/Payara Server Documentation/Jakarta EE API/JBatch API/Schema Name.adoc[Schema Name]
-**** xref:Technical Documentation/Payara Server Documentation/Jakarta EE API/JBatch API/Table Prefix and Suffix.adoc[Table Prefix and Suffix]
+*** Enterprise Java Beans (EJB)
+**** xref:Technical Documentation/Payara Server Documentation/Jakarta EE API/Enterprise Java Beans (EJB)/Overview.adoc[Overview]
+**** xref:Technical Documentation/Payara Server Documentation/Jakarta EE API/Enterprise Java Beans (EJB)/Tracing Remote EJBs.adoc[Tracing Remote EJBs]
+**** xref:Technical Documentation/Payara Server Documentation/Jakarta EE API/Enterprise Java Beans (EJB)/JDK 17 Support.adoc[JDK 17 Support]
 *** JPA
 **** xref:Technical Documentation/Payara Server Documentation/Jakarta EE API/JPA/JPA Cache Coordination.adoc[JPA Cache Coordination]
 *** JSF API
 **** xref:Technical Documentation/Payara Server Documentation/Jakarta EE API/JSF API/JSF Options.adoc[JSF Options]
+*** JBatch API
+**** xref:Technical Documentation/Payara Server Documentation/Jakarta EE API/JBatch API/Overview.adoc[Overview]
+**** xref:Technical Documentation/Payara Server Documentation/Jakarta EE API/JBatch API/Schema Name.adoc[Schema Name]
+**** xref:Technical Documentation/Payara Server Documentation/Jakarta EE API/JBatch API/Table Prefix and Suffix.adoc[Table Prefix and Suffix]
+**** xref:Technical Documentation/Payara Server Documentation/Jakarta EE API/JBatch API/Database Support.adoc[Database Support]
+**** xref:Technical Documentation/Payara Server Documentation/Jakarta EE API/JBatch API/Improved Asadmin CLI.adoc[Improved Asadmin CLI]
 ** Logging and Monitoring
 *** xref:Technical Documentation/Payara Server Documentation/Logging and Monitoring/Logging.adoc[Logging]
-*** xref:Technical Documentation/Payara Server Documentation/Logging and Monitoring/HealthCheck Service.adoc[HealthCheck Service]
 *** xref:Technical Documentation/Payara Server Documentation/Logging and Monitoring/Monitoring Console.adoc[Monitoring Console]
-*** Monitoring Service
-**** xref:Technical Documentation/Payara Server Documentation/Logging and Monitoring/Monitoring Service/Basic Monitoring Configuration.adoc[Basic Monitoring Configuration]
-**** xref:Technical Documentation/Payara Server Documentation/Logging and Monitoring/Monitoring Service/JMX Monitoring.adoc[JMX Monitoring]
-**** xref:Technical Documentation/Payara Server Documentation/Logging and Monitoring/Monitoring Service/MBeans.adoc[MBeans]
-**** xref:Technical Documentation/Payara Server Documentation/Logging and Monitoring/Monitoring Service/Rest Monitoring.adoc[Rest Monitoring]
+*** xref:Technical Documentation/Payara Server Documentation/Logging and Monitoring/HealthCheck Service.adoc[HealthCheck Service]
+*** Request Tracing Service
+**** xref:Technical Documentation/Payara Server Documentation/Logging and Monitoring/Request Tracing Service/Terminology.adoc[Terminology]
+**** xref:Technical Documentation/Payara Server Documentation/Logging and Monitoring/Request Tracing Service/Configuration.adoc[Configuration]
+**** xref:Technical Documentation/Payara Server Documentation/Logging and Monitoring/Request Tracing Service/Asadmin Commands.adoc[Asadmin Commands]
+**** xref:Technical Documentation/Payara Server Documentation/Logging and Monitoring/Request Tracing Service/Usage.adoc[Usage]
+**** xref:Technical Documentation/Payara Server Documentation/Logging and Monitoring/Request Tracing Service/Overview.adoc[Overview]
 *** Notification Service
 **** xref:Technical Documentation/Payara Server Documentation/Logging and Monitoring/Notification Service/Overview.adoc[Overview]
 **** JMX Monitoring Notifications
 ***** xref:Technical Documentation/Payara Server Documentation/Logging and Monitoring/Notification Service/JMX Monitoring Notifications/JMX Monitoring Notifiers Asadmin Commands.adoc[JMX Monitoring Notifiers Asadmin Commands]
 ***** xref:Technical Documentation/Payara Server Documentation/Logging and Monitoring/Notification Service/JMX Monitoring Notifications/JMX Monitoring Notifiers Configuration.adoc[JMX Monitoring Notifiers Configuration]
-*** Request Tracing Service
-**** xref:Technical Documentation/Payara Server Documentation/Logging and Monitoring/Request Tracing Service/Overview.adoc[Overview]
-**** xref:Technical Documentation/Payara Server Documentation/Logging and Monitoring/Request Tracing Service/Asadmin Commands.adoc[Asadmin Commands]
-**** xref:Technical Documentation/Payara Server Documentation/Logging and Monitoring/Request Tracing Service/Configuration.adoc[Configuration]
-**** xref:Technical Documentation/Payara Server Documentation/Logging and Monitoring/Request Tracing Service/Terminology.adoc[Terminology]
-**** xref:Technical Documentation/Payara Server Documentation/Logging and Monitoring/Request Tracing Service/Usage.adoc[Usage]
+*** Monitoring Service
+**** xref:Technical Documentation/Payara Server Documentation/Logging and Monitoring/Monitoring Service/Rest Monitoring.adoc[Rest Monitoring]
+**** xref:Technical Documentation/Payara Server Documentation/Logging and Monitoring/Monitoring Service/MBeans.adoc[MBeans]
+**** xref:Technical Documentation/Payara Server Documentation/Logging and Monitoring/Monitoring Service/JMX Monitoring.adoc[JMX Monitoring]
+**** xref:Technical Documentation/Payara Server Documentation/Logging and Monitoring/Monitoring Service/Basic Monitoring Configuration.adoc[Basic Monitoring Configuration]
 ** Management and Monitoring REST API
 *** xref:Technical Documentation/Payara Server Documentation/Management and Monitoring REST API/Overview.adoc[Overview]
-*** xref:Technical Documentation/Payara Server Documentation/Management and Monitoring REST API/Definitions.adoc[Definitions]
 *** xref:Technical Documentation/Payara Server Documentation/Management and Monitoring REST API/Rest API.adoc[Rest API]
-** Server Configuration And Management
-*** Admin Console Enhancements
-**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Admin Console Enhancements/Overview.adoc[Overview]
-**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Admin Console Enhancements/Asadmin Recorder.adoc[Asadmin Recorder]
-**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Admin Console Enhancements/Auditing Service.adoc[Auditing Service]
-**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Admin Console Enhancements/Environment Warning.adoc[Environment Warning]
-*** Application Deployment
-**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Application Deployment/Overview.adoc[Overview]
-**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Application Deployment/Concurrent CDI Bean Loading.adoc[Concurrent CDI Bean Loading]
-**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Application Deployment/Deployment Descriptors.adoc[Deployment Descriptors]
-**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Application Deployment/Descriptor Elements.adoc[Descriptor Elements]
-*** Asadmin Commands
-**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Asadmin Commands/Auto Naming.adoc[Auto Naming]
-**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Asadmin Commands/Multimode Event Designators Support.adoc[Multimode Event Designators Support]
-**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Asadmin Commands/Print Certificate Data.adoc[Print Certificate Data]
-**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Asadmin Commands/Server Management Asadmin Commands.adoc[Server Management Asadmin Commands]
-*** Classloading
-**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Classloading/Overview.adoc[Overview]
-**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Classloading/Enhanced Classloading.adoc[Enhanced Classloading]
-**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Classloading/Standard Classloading.adoc[Standard Classloading]
-*** Configuration Options
-**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Configuration Options/JVM Options.adoc[JVM Options]
-**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Configuration Options/Password Aliases.adoc[Password Aliases]
-**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Configuration Options/Phone Home.adoc[Phone Home]
-**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Configuration Options/SSL Certificates.adoc[SSL Certificates]
-**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Configuration Options/System Properties.adoc[System Properties]
-**** Variable Substitution
-***** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Configuration Options/Variable Substitution/Types of Variables.adoc[Types of Variables]
-***** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Configuration Options/Variable Substitution/Usage of Variables.adoc[Usage of Variables]
-*** Docker Host Support
-**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Docker Host Support/Docker Instances.adoc[Docker Instances]
-**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Docker Host Support/Docker Nodes.adoc[Docker Nodes]
-*** Domain Data Grid And Hazelcast
-**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Domain Data Grid And Hazelcast/Overview.adoc[Overview]
-**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Domain Data Grid And Hazelcast/Configuration.adoc[Configuration]
-**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Domain Data Grid And Hazelcast/Datagrid in Applications.adoc[Datagrid in Applications]
-**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Domain Data Grid And Hazelcast/Discovery.adoc[Discovery]
-**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Domain Data Grid And Hazelcast/Encryption.adoc[Encryption]
-**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Domain Data Grid And Hazelcast/Viewing Members.adoc[Viewing Members]
-*** HTTP Service
-**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/HTTP Service/Overview.adoc[Overview]
-**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/HTTP Service/Network Listeners.adoc[Network Listeners]
-**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/HTTP Service/Protocols.adoc[Protocols]
-**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/HTTP Service/Virtual Servers.adoc[Virtual Servers]
-*** JDBC Resource Management
-**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/JDBC Resource Management/JDBC.adoc[JDBC]
-**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/JDBC Resource Management/SQL.adoc[SQL]
-*** Security Configuration
-**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Security Configuration/Overview.adoc[Overview]
-**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Security Configuration/JACC.adoc[JACC]
-**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Security Configuration/JCE Provider Support.adoc[JCE Provider Support]
-**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Security Configuration/Multiple Mechanism in EAR.adoc[Multiple Mechanism in EAR]
-**** Client Certificates
-***** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Security Configuration/Client Certificates/Advanced Groups Configuration.adoc[Advanced Groups Configuration]
-***** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Security Configuration/Client Certificates/Advanced Principal Name Configuration.adoc[Advanced Principal Name Configuration]
-***** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Security Configuration/Client Certificates/Custom Validators.adoc[Custom Validators]
-*** Thread Pools
-**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Thread Pools/Default Thread Pool Size.adoc[Default Thread Pool Size]
-**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Thread Pools/EJB Thread Pool.adoc[EJB Thread Pool]
+*** xref:Technical Documentation/Payara Server Documentation/Management and Monitoring REST API/Definitions.adoc[Definitions]
+* Ecosystem
+** xref:Technical Documentation/Ecosystem/Overview.adoc[Overview]
+** Miscellaneous
+*** xref:Technical Documentation/Ecosystem/Miscellaneous/JAX-RS Extension.adoc[JAX-RS Extension]
+** Project Management Tools
+*** xref:Technical Documentation/Ecosystem/Project Management Tools/Gradle Plugin.adoc[Gradle Plugin]
+*** xref:Technical Documentation/Ecosystem/Project Management Tools/Maven Bom.adoc[Maven Bom]
+*** xref:Technical Documentation/Ecosystem/Project Management Tools/Maven Archetype.adoc[Maven Archetype]
+*** xref:Technical Documentation/Ecosystem/Project Management Tools/Maven Plugin.adoc[Maven Plugin]
+** Connector Suites
+*** xref:Technical Documentation/Ecosystem/Connector Suites/Security Connectors.adoc[Security Connectors]
+*** Cloud Connectors
+**** xref:Technical Documentation/Ecosystem/Connector Suites/Cloud Connectors/Amazon SQS.adoc[Amazon SQS]
+**** xref:Technical Documentation/Ecosystem/Connector Suites/Cloud Connectors/Azure SB.adoc[Azure SB]
+**** xref:Technical Documentation/Ecosystem/Connector Suites/Cloud Connectors/Apache Kafka.adoc[Apache Kafka]
+**** xref:Technical Documentation/Ecosystem/Connector Suites/Cloud Connectors/MQTT.adoc[MQTT]
+**** xref:Technical Documentation/Ecosystem/Connector Suites/Cloud Connectors/Overview.adoc[Overview]
+*** Arquillian Containers
+**** xref:Technical Documentation/Ecosystem/Connector Suites/Arquillian Containers/Overview.adoc[Overview]
+**** xref:Technical Documentation/Ecosystem/Connector Suites/Arquillian Containers/Payara Micro Managed.adoc[Payara Micro Managed]
+**** xref:Technical Documentation/Ecosystem/Connector Suites/Arquillian Containers/Payara Server Remote.adoc[Payara Server Remote]
+**** xref:Technical Documentation/Ecosystem/Connector Suites/Arquillian Containers/Payara Server Managed.adoc[Payara Server Managed]
+**** xref:Technical Documentation/Ecosystem/Connector Suites/Arquillian Containers/Payara Server Embedded.adoc[Payara Server Embedded]
+** IDE Integration
+*** Eclipse Plugin
+**** xref:Technical Documentation/Ecosystem/IDE Integration/Eclipse Plugin/Overview.adoc[Overview]
+**** xref:Technical Documentation/Ecosystem/IDE Integration/Eclipse Plugin/Payara Server.adoc[Payara Server]
+**** xref:Technical Documentation/Ecosystem/IDE Integration/Eclipse Plugin/Payara Micro.adoc[Payara Micro]
+*** NetBeans Plugin
+**** xref:Technical Documentation/Ecosystem/IDE Integration/NetBeans Plugin/Overview.adoc[Overview]
+**** xref:Technical Documentation/Ecosystem/IDE Integration/NetBeans Plugin/Payara Server.adoc[Payara Server]
+**** xref:Technical Documentation/Ecosystem/IDE Integration/NetBeans Plugin/Payara Micro.adoc[Payara Micro]
+*** VSCode Extension
+**** xref:Technical Documentation/Ecosystem/IDE Integration/VSCode Extension/Overview.adoc[Overview]
+**** xref:Technical Documentation/Ecosystem/IDE Integration/VSCode Extension/Payara Server.adoc[Payara Server]
+**** xref:Technical Documentation/Ecosystem/IDE Integration/VSCode Extension/Payara Micro.adoc[Payara Micro]
+*** Intellij Plugin
+**** xref:Technical Documentation/Ecosystem/IDE Integration/Intellij Plugin/Overview.adoc[Overview]
+**** xref:Technical Documentation/Ecosystem/IDE Integration/Intellij Plugin/Payara Server.adoc[Payara Server]
+**** xref:Technical Documentation/Ecosystem/IDE Integration/Intellij Plugin/Payara Micro.adoc[Payara Micro]
+* MicroProfile
+** xref:Technical Documentation/MicroProfile/Overview.adoc[Overview]
+** xref:Technical Documentation/MicroProfile/JWT.adoc[JWT]
+** xref:Technical Documentation/MicroProfile/Rest Client.adoc[Rest Client]
+** xref:Technical Documentation/MicroProfile/OpenAPI.adoc[OpenAPI]
+** xref:Technical Documentation/MicroProfile/Fault Tolerance.adoc[Fault Tolerance]
+** xref:Technical Documentation/MicroProfile/HealthCheck.adoc[HealthCheck]
+** xref:Technical Documentation/MicroProfile/Opentracing.adoc[Opentracing]
+** Metrics
+*** xref:Technical Documentation/MicroProfile/Metrics/Metrics Rest Endpoint.adoc[Metrics Rest Endpoint]
+*** xref:Technical Documentation/MicroProfile/Metrics/Vendor Metrics.adoc[Vendor Metrics]
+*** xref:Technical Documentation/MicroProfile/Metrics/Metrics Configuration.adoc[Metrics Configuration]
+** Config
+*** xref:Technical Documentation/MicroProfile/Config/Overview.adoc[Overview]
+*** xref:Technical Documentation/MicroProfile/Config/JDBC.adoc[JDBC]
+*** xref:Technical Documentation/MicroProfile/Config/LDAP.adoc[LDAP]
+*** xref:Technical Documentation/MicroProfile/Config/Directory.adoc[Directory]
+*** Cloud
+**** xref:Technical Documentation/MicroProfile/Config/Cloud/Overview.adoc[Overview]
+**** xref:Technical Documentation/MicroProfile/Config/Cloud/GCP.adoc[GCP]
+**** xref:Technical Documentation/MicroProfile/Config/Cloud/Hashicorp.adoc[Hashicorp]
+**** xref:Technical Documentation/MicroProfile/Config/Cloud/DynamoDB.adoc[DynamoDB]
+**** xref:Technical Documentation/MicroProfile/Config/Cloud/AWS.adoc[AWS]
+**** xref:Technical Documentation/MicroProfile/Config/Cloud/Azure.adoc[Azure]
 * Public API
 ** xref:Technical Documentation/Public API/Overview.adoc[Overview]
+** xref:Technical Documentation/Public API/Roles Permitted.adoc[Roles Permitted]
 ** xref:Technical Documentation/Public API/CDI Events.adoc[CDI Events]
-** xref:Technical Documentation/Public API/Clustered Singleton.adoc[Clustered Singleton]
 ** xref:Technical Documentation/Public API/OAuth Support.adoc[OAuth Support]
 ** xref:Technical Documentation/Public API/OpenID Connect Support.adoc[OpenID Connect Support]
-** xref:Technical Documentation/Public API/Roles Permitted.adoc[Roles Permitted]
 ** xref:Technical Documentation/Public API/Security Extensions.adoc[Security Extensions]
+** xref:Technical Documentation/Public API/Clustered Singleton.adoc[Clustered Singleton]
 
 include::partial$release-notes.adoc[Release Notes]
 
@@ -275,6 +275,6 @@ include::partial$eclipse-microprofile.adoc[Eclipse MicroProfile Certification]
 .Appendix
 * Schemas
 ** xref:Appendix/Schemas/Overview.adoc[Overview]
-** xref:Appendix/Schemas/payara-resources_1_6.dtd[payara-resources_1_6.dtd]
 ** xref:Appendix/Schemas/payara-resources_1_7.dtd[payara-resources_1_7.dtd]
 ** xref:Appendix/Schemas/payara-web-app_4.dtd[payara-web-app_4.dtd]
+** xref:Appendix/Schemas/payara-resources_1_6.dtd[payara-resources_1_6.dtd]

--- a/community/docs/modules/ROOT/pages/Technical Documentation/Payara Server Documentation/Logging and Monitoring/Request Tracing Service/Overview.adoc
+++ b/community/docs/modules/ROOT/pages/Technical Documentation/Payara Server Documentation/Logging and Monitoring/Request Tracing Service/Overview.adoc
@@ -45,7 +45,9 @@ NOTE: The new MicroProfile `@Traced` annotation replaces the Payara Server & Mic
 |===
 |Payara Server & Micro Version
 |OpenTracing.io API Version
-| 4.1.2.183 - 4.1.2.191; 5.183 - {page-version}
+| 5.2022.1 - {page-version}
+| 0.33
+| 4.1.2.183 - 4.1.2.191; 5.183 - 5.2020.7
 | 0.31
 | 4.1.2.182; 5.182
 | 0.30

--- a/community/docs/modules/ROOT/pages/Technical Documentation/Payara Server Documentation/Logging and Monitoring/Request Tracing Service/Overview.adoc
+++ b/community/docs/modules/ROOT/pages/Technical Documentation/Payara Server Documentation/Logging and Monitoring/Request Tracing Service/Overview.adoc
@@ -6,7 +6,7 @@ The Request Tracing Service provides tracing facilities for multiple protocols a
 
 The service helps users to detect application slowness and performance degradation by logging requests that exceed a given threshold. The trace data from long-running requests gives insight to solving bottlenecks and other performance issues.
 
-NOTE: The service is available in both Payara Server and Payara Micro, though the  service configuration is different in Payara Micro.
+NOTE: The service is available in both Payara Server and Payara Micro, though the  service configuration is different in xref:Technical Documentation/Payara Micro Documentation/Logging and Monitoring/Request Tracing.adoc[Payara Micro].
 
 The following types of requests are traced if the service is enabled:
 

--- a/enterprise/docs/modules/ROOT/nav.adoc
+++ b/enterprise/docs/modules/ROOT/nav.adoc
@@ -5,261 +5,261 @@
 * xref:General Info/Supported Platforms.adoc[Supported Platforms]
 
 .Technical Documentation
-* Ecosystem
-** xref:Technical Documentation/Ecosystem/Overview.adoc[Overview]
-** Connector Suites
-*** xref:Technical Documentation/Ecosystem/Connector Suites/Security Connectors.adoc[Security Connectors]
-*** Arquillian Containers
-**** xref:Technical Documentation/Ecosystem/Connector Suites/Arquillian Containers/Overview.adoc[Overview]
-**** xref:Technical Documentation/Ecosystem/Connector Suites/Arquillian Containers/Payara Micro Managed.adoc[Payara Micro Managed]
-**** xref:Technical Documentation/Ecosystem/Connector Suites/Arquillian Containers/Payara Server Embedded.adoc[Payara Server Embedded]
-**** xref:Technical Documentation/Ecosystem/Connector Suites/Arquillian Containers/Payara Server Managed.adoc[Payara Server Managed]
-**** xref:Technical Documentation/Ecosystem/Connector Suites/Arquillian Containers/Payara Server Remote.adoc[Payara Server Remote]
-*** Cloud Connectors
-**** xref:Technical Documentation/Ecosystem/Connector Suites/Cloud Connectors/Amazon SQS.adoc[Amazon SQS]
-**** xref:Technical Documentation/Ecosystem/Connector Suites/Cloud Connectors/Apache Kafka.adoc[Apache Kafka]
-**** xref:Technical Documentation/Ecosystem/Connector Suites/Cloud Connectors/Azure SB.adoc[Azure SB]
-**** xref:Technical Documentation/Ecosystem/Connector Suites/Cloud Connectors/MQTT.adoc[MQTT]
-**** xref:Technical Documentation/Ecosystem/Connector Suites/Cloud Connectors/Overview.adoc[Overview]
-** IDE Integration
-*** Eclipse Plugin
-**** xref:Technical Documentation/Ecosystem/IDE Integration/Eclipse Plugin/Overview.adoc[Overview]
-**** xref:Technical Documentation/Ecosystem/IDE Integration/Eclipse Plugin/Payara Micro.adoc[Payara Micro]
-**** xref:Technical Documentation/Ecosystem/IDE Integration/Eclipse Plugin/Payara Server.adoc[Payara Server]
-*** Intellij Plugin
-**** xref:Technical Documentation/Ecosystem/IDE Integration/Intellij Plugin/Overview.adoc[Overview]
-**** xref:Technical Documentation/Ecosystem/IDE Integration/Intellij Plugin/Payara Micro.adoc[Payara Micro]
-**** xref:Technical Documentation/Ecosystem/IDE Integration/Intellij Plugin/Payara Server.adoc[Payara Server]
-*** NetBeans Plugin
-**** xref:Technical Documentation/Ecosystem/IDE Integration/NetBeans Plugin/Overview.adoc[Overview]
-**** xref:Technical Documentation/Ecosystem/IDE Integration/NetBeans Plugin/Payara Micro.adoc[Payara Micro]
-**** xref:Technical Documentation/Ecosystem/IDE Integration/NetBeans Plugin/Payara Server.adoc[Payara Server]
-*** VSCode Extension
-**** xref:Technical Documentation/Ecosystem/IDE Integration/VSCode Extension/Overview.adoc[Overview]
-**** xref:Technical Documentation/Ecosystem/IDE Integration/VSCode Extension/Payara Micro.adoc[Payara Micro]
-**** xref:Technical Documentation/Ecosystem/IDE Integration/VSCode Extension/Payara Server.adoc[Payara Server]
-** Miscellaneous
-*** xref:Technical Documentation/Ecosystem/Miscellaneous/JAX-RS Extension.adoc[JAX-RS Extension]
-** Project Management Tools
-*** xref:Technical Documentation/Ecosystem/Project Management Tools/Gradle Plugin.adoc[Gradle Plugin]
-*** xref:Technical Documentation/Ecosystem/Project Management Tools/Maven Archetype.adoc[Maven Archetype]
-*** xref:Technical Documentation/Ecosystem/Project Management Tools/Maven Bom.adoc[Maven Bom]
-*** xref:Technical Documentation/Ecosystem/Project Management Tools/Maven Plugin.adoc[Maven Plugin]
-* MicroProfile
-** xref:Technical Documentation/MicroProfile/Overview.adoc[Overview]
-** xref:Technical Documentation/MicroProfile/JWT.adoc[JWT]
-** xref:Technical Documentation/MicroProfile/Rest Client.adoc[Rest Client]
-** xref:Technical Documentation/MicroProfile/Fault Tolerance.adoc[Fault Tolerance]
-** xref:Technical Documentation/MicroProfile/HealthCheck.adoc[HealthCheck]
-** xref:Technical Documentation/MicroProfile/OpenAPI.adoc[OpenAPI]
-** xref:Technical Documentation/MicroProfile/Opentracing.adoc[Opentracing]
-** Config
-*** xref:Technical Documentation/MicroProfile/Config/Overview.adoc[Overview]
-*** xref:Technical Documentation/MicroProfile/Config/Directory.adoc[Directory]
-*** xref:Technical Documentation/MicroProfile/Config/JDBC.adoc[JDBC]
-*** xref:Technical Documentation/MicroProfile/Config/LDAP.adoc[LDAP]
-*** Cloud
-**** xref:Technical Documentation/MicroProfile/Config/Cloud/Overview.adoc[Overview]
-**** xref:Technical Documentation/MicroProfile/Config/Cloud/AWS.adoc[AWS]
-**** xref:Technical Documentation/MicroProfile/Config/Cloud/DynamoDB.adoc[DynamoDB]
-**** xref:Technical Documentation/MicroProfile/Config/Cloud/GCP.adoc[GCP]
-**** xref:Technical Documentation/MicroProfile/Config/Cloud/Hashicorp.adoc[Hashicorp]
-**** xref:Technical Documentation/MicroProfile/Config/Cloud/Azure.adoc[Azure]
-** Metrics
-*** xref:Technical Documentation/MicroProfile/Metrics/Metrics Configuration.adoc[Metrics Configuration]
-*** xref:Technical Documentation/MicroProfile/Metrics/Metrics Rest Endpoint.adoc[Metrics Rest Endpoint]
-*** xref:Technical Documentation/MicroProfile/Metrics/Vendor Metrics.adoc[Vendor Metrics]
 * Payara Micro Documentation
 ** xref:Technical Documentation/Payara Micro Documentation/Overview.adoc[Overview]
 ** xref:Technical Documentation/Payara Micro Documentation/Maven Support.adoc[Maven Support]
 ** xref:Technical Documentation/Payara Micro Documentation/Payara Micro Docker Image.adoc[Payara Micro Docker Image]
-** API
-*** xref:Technical Documentation/Payara Micro Documentation/API/JCache in Payara Micro.adoc[JCache in Payara Micro]
-*** Payara Micro API
-**** xref:Technical Documentation/Payara Micro Documentation/API/Payara Micro API/Overview.adoc[Overview]
-**** xref:Technical Documentation/Payara Micro Documentation/API/Payara Micro API/Using the Payara Micro API.adoc[Using the Payara Micro API]
 ** Extensions
-*** xref:Technical Documentation/Payara Micro Documentation/Extensions/JCA Support.adoc[JCA Support]
 *** xref:Technical Documentation/Payara Micro Documentation/Extensions/Persistent EJB Timers.adoc[Persistent EJB Timers]
 *** xref:Technical Documentation/Payara Micro Documentation/Extensions/Remote CDI Events.adoc[Remote CDI Events]
 *** xref:Technical Documentation/Payara Micro Documentation/Extensions/Running Callable Objects.adoc[Running Callable Objects]
+*** xref:Technical Documentation/Payara Micro Documentation/Extensions/JCA Support.adoc[JCA Support]
+** Payara Micro Configuration and Management
+*** Micro Management
+**** xref:Technical Documentation/Payara Micro Documentation/Payara Micro Configuration and Management/Micro Management/Configuring An Instance.adoc[Configuring An Instance]
+**** xref:Technical Documentation/Payara Micro Documentation/Payara Micro Configuration and Management/Micro Management/Clustering.adoc[Clustering]
+**** xref:Technical Documentation/Payara Micro Documentation/Payara Micro Configuration and Management/Micro Management/HTTP(S) Auto-Binding.adoc[HTTP(S) Auto-Binding]
+**** Jar Structure and Configuration
+***** xref:Technical Documentation/Payara Micro Documentation/Payara Micro Configuration and Management/Micro Management/Jar Structure and Configuration/Payara Micro Jar Structure.adoc[Payara Micro Jar Structure]
+***** xref:Technical Documentation/Payara Micro Documentation/Payara Micro Configuration and Management/Micro Management/Jar Structure and Configuration/Root Directory.adoc[Root Directory]
+***** xref:Technical Documentation/Payara Micro Documentation/Payara Micro Configuration and Management/Micro Management/Jar Structure and Configuration/Adding Jars.adoc[Adding Jars]
+**** Stopping and Starting Instances
+***** xref:Technical Documentation/Payara Micro Documentation/Payara Micro Configuration and Management/Micro Management/Stopping and Starting Instances/Stopping Instance.adoc[Stopping Instance]
+***** xref:Technical Documentation/Payara Micro Documentation/Payara Micro Configuration and Management/Micro Management/Stopping and Starting Instances/Starting Instance.adoc[Starting Instance]
+**** Deploying Applications
+***** xref:Technical Documentation/Payara Micro Documentation/Payara Micro Configuration and Management/Micro Management/Deploying Applications/Deploy Applications Programmatically.adoc[Deploy Applications Programmatically]
+***** xref:Technical Documentation/Payara Micro Documentation/Payara Micro Configuration and Management/Micro Management/Deploying Applications/Deploy Applications.adoc[Deploy Applications]
+**** Command Line Options
+***** xref:Technical Documentation/Payara Micro Documentation/Payara Micro Configuration and Management/Micro Management/Command Line Options/Disable Phone Home.adoc[Disable Phone Home]
+***** xref:Technical Documentation/Payara Micro Documentation/Payara Micro Configuration and Management/Micro Management/Command Line Options/Command Line Options.adoc[Command Line Options]
+**** Asadmin Commands
+***** xref:Technical Documentation/Payara Micro Documentation/Payara Micro Configuration and Management/Micro Management/Asadmin Commands/Send Asadmin Commands from Admin Console.adoc[Send Asadmin Commands from Admin Console]
+***** xref:Technical Documentation/Payara Micro Documentation/Payara Micro Configuration and Management/Micro Management/Asadmin Commands/Pre and Post Boot Commands.adoc[Pre and Post Boot Commands]
+*** Database Management
+**** xref:Technical Documentation/Payara Micro Documentation/Payara Micro Configuration and Management/Database Management/Slow SQL Logger.adoc[Slow SQL Logger]
+**** xref:Technical Documentation/Payara Micro Documentation/Payara Micro Configuration and Management/Database Management/Log JDBC Calls.adoc[Log JDBC Calls]
+**** xref:Technical Documentation/Payara Micro Documentation/Payara Micro Configuration and Management/Database Management/SQL Trace Listeners.adoc[SQL Trace Listeners]
 ** Logging and Monitoring
 *** xref:Technical Documentation/Payara Micro Documentation/Logging and Monitoring/Request Tracing.adoc[Request Tracing]
 *** Logging
 **** xref:Technical Documentation/Payara Micro Documentation/Logging and Monitoring/Logging/Config Access Log.adoc[Config Access Log]
 **** xref:Technical Documentation/Payara Micro Documentation/Logging and Monitoring/Logging/Logging to File.adoc[Logging to File]
-** Payara Micro Configuration and Management
-*** Database Management
-**** xref:Technical Documentation/Payara Micro Documentation/Payara Micro Configuration and Management/Database Management/Log JDBC Calls.adoc[Log JDBC Calls]
-**** xref:Technical Documentation/Payara Micro Documentation/Payara Micro Configuration and Management/Database Management/Slow SQL Logger.adoc[Slow SQL Logger]
-**** xref:Technical Documentation/Payara Micro Documentation/Payara Micro Configuration and Management/Database Management/SQL Trace Listeners.adoc[SQL Trace Listeners]
-*** Micro Management
-**** xref:Technical Documentation/Payara Micro Documentation/Payara Micro Configuration and Management/Micro Management/Clustering.adoc[Clustering]
-**** xref:Technical Documentation/Payara Micro Documentation/Payara Micro Configuration and Management/Micro Management/Configuring An Instance.adoc[Configuring An Instance]
-**** xref:Technical Documentation/Payara Micro Documentation/Payara Micro Configuration and Management/Micro Management/HTTP(S) Auto-Binding.adoc[HTTP(S) Auto-Binding]
-**** Asadmin Commands
-***** xref:Technical Documentation/Payara Micro Documentation/Payara Micro Configuration and Management/Micro Management/Asadmin Commands/Pre and Post Boot Commands.adoc[Pre and Post Boot Commands]
-***** xref:Technical Documentation/Payara Micro Documentation/Payara Micro Configuration and Management/Micro Management/Asadmin Commands/Send Asadmin Commands from Admin Console.adoc[Send Asadmin Commands from Admin Console]
-**** Command Line Options
-***** xref:Technical Documentation/Payara Micro Documentation/Payara Micro Configuration and Management/Micro Management/Command Line Options/Command Line Options.adoc[Command Line Options]
-***** xref:Technical Documentation/Payara Micro Documentation/Payara Micro Configuration and Management/Micro Management/Command Line Options/Disable Phone Home.adoc[Disable Phone Home]
-**** Deploying Applications
-***** xref:Technical Documentation/Payara Micro Documentation/Payara Micro Configuration and Management/Micro Management/Deploying Applications/Deploy Applications Programmatically.adoc[Deploy Applications Programmatically]
-***** xref:Technical Documentation/Payara Micro Documentation/Payara Micro Configuration and Management/Micro Management/Deploying Applications/Deploy Applications.adoc[Deploy Applications]
-**** Jar Structure and Configuration
-***** xref:Technical Documentation/Payara Micro Documentation/Payara Micro Configuration and Management/Micro Management/Jar Structure and Configuration/Adding Jars.adoc[Adding Jars]
-***** xref:Technical Documentation/Payara Micro Documentation/Payara Micro Configuration and Management/Micro Management/Jar Structure and Configuration/Payara Micro Jar Structure.adoc[Payara Micro Jar Structure]
-***** xref:Technical Documentation/Payara Micro Documentation/Payara Micro Configuration and Management/Micro Management/Jar Structure and Configuration/Root Directory.adoc[Root Directory]
-**** Stopping and Starting Instances
-***** xref:Technical Documentation/Payara Micro Documentation/Payara Micro Configuration and Management/Micro Management/Stopping and Starting Instances/Starting Instance.adoc[Starting Instance]
-***** xref:Technical Documentation/Payara Micro Documentation/Payara Micro Configuration and Management/Micro Management/Stopping and Starting Instances/Stopping Instance.adoc[Stopping Instance]
+** API
+*** xref:Technical Documentation/Payara Micro Documentation/API/JCache in Payara Micro.adoc[JCache in Payara Micro]
+*** Payara Micro API
+**** xref:Technical Documentation/Payara Micro Documentation/API/Payara Micro API/Overview.adoc[Overview]
+**** xref:Technical Documentation/Payara Micro Documentation/API/Payara Micro API/Using the Payara Micro API.adoc[Using the Payara Micro API]
 * Payara Server Documentation
 ** xref:Technical Documentation/Payara Server Documentation/Overview.adoc[Overview]
 ** xref:Technical Documentation/Payara Server Documentation/Payara Server Embedded.adoc[Payara Server Embedded]
 ** xref:Technical Documentation/Payara Server Documentation/Payara Server Docker Image.adoc[Payara Server Docker Image]
 ** Upgrade Payara
 *** xref:Technical Documentation/Payara Server Documentation/Upgrade Payara/Overview.adoc[Overview]
-*** xref:Technical Documentation/Payara Server Documentation/Upgrade Payara/Backup and Restore Method.adoc[Backup and Restore Method]
 *** xref:Technical Documentation/Payara Server Documentation/Upgrade Payara/Domain and Node Directories Method.adoc[Domain and Node Directories Method]
+*** xref:Technical Documentation/Payara Server Documentation/Upgrade Payara/Backup and Restore Method.adoc[Backup and Restore Method]
 *** xref:Technical Documentation/Payara Server Documentation/Upgrade Payara/Upgrade Tool.adoc[Upgrade Tool]
-** Deployment Groups
-*** xref:Technical Documentation/Payara Server Documentation/Deployment Groups/Overview.adoc[Overview]
-*** xref:Technical Documentation/Payara Server Documentation/Deployment Groups/Asadmin Commands.adoc[Asadmin Commands]
-*** xref:Technical Documentation/Payara Server Documentation/Deployment Groups/Timers.adoc[Timers]
-** Development Debugging And Assistance Tools
-*** xref:Technical Documentation/Payara Server Documentation/Development Debugging And Assistance Tools/CDI.adoc[CDI]
 ** Extensions
 *** xref:Technical Documentation/Payara Server Documentation/Extensions/Overview.adoc[Overview]
 *** gRPC Support
 **** xref:Technical Documentation/Payara Server Documentation/Extensions/gRPC Support/Overview.adoc[Overview]
 **** xref:Technical Documentation/Payara Server Documentation/Extensions/gRPC Support/Usage.adoc[Usage]
 **** xref:Technical Documentation/Payara Server Documentation/Extensions/gRPC Support/Installation.adoc[Installation]
-** Jakarta EE API
-*** xref:Technical Documentation/Payara Server Documentation/Jakarta EE API/JavaMail API.adoc[JavaMail API]
-*** xref:Technical Documentation/Payara Server Documentation/Jakarta EE API/JAX-WS Enhancements.adoc[JAX-WS Enhancements]
-*** xref:Technical Documentation/Payara Server Documentation/Jakarta EE API/JCache API.adoc[JCache API]
-*** Enterprise Java Beans (EJB)
-**** xref:Technical Documentation/Payara Server Documentation/Jakarta EE API/Enterprise Java Beans (EJB)/Overview.adoc[Overview]
-**** xref:Technical Documentation/Payara Server Documentation/Jakarta EE API/Enterprise Java Beans (EJB)/JDK 17 Support.adoc[JDK 17 Support]
-**** xref:Technical Documentation/Payara Server Documentation/Jakarta EE API/Enterprise Java Beans (EJB)/Tracing Remote EJBs.adoc[Tracing Remote EJBs]
-*** JAX-RS
-**** xref:Technical Documentation/Payara Server Documentation/Jakarta EE API/JAX-RS/CDI With JAX-RS.adoc[CDI With JAX-RS]
-*** JBatch API
-**** xref:Technical Documentation/Payara Server Documentation/Jakarta EE API/JBatch API/Overview.adoc[Overview]
-**** xref:Technical Documentation/Payara Server Documentation/Jakarta EE API/JBatch API/Database Support.adoc[Database Support]
-**** xref:Technical Documentation/Payara Server Documentation/Jakarta EE API/JBatch API/Improved Asadmin CLI.adoc[Improved Asadmin CLI]
-**** xref:Technical Documentation/Payara Server Documentation/Jakarta EE API/JBatch API/Schema Name.adoc[Schema Name]
-**** xref:Technical Documentation/Payara Server Documentation/Jakarta EE API/JBatch API/Table Prefix and Suffix.adoc[Table Prefix and Suffix]
-*** JPA
-**** xref:Technical Documentation/Payara Server Documentation/Jakarta EE API/JPA/JPA Cache Coordination.adoc[JPA Cache Coordination]
-*** JSF API
-**** xref:Technical Documentation/Payara Server Documentation/Jakarta EE API/JSF API/JSF Options.adoc[JSF Options]
-** Logging and Monitoring
-*** xref:Technical Documentation/Payara Server Documentation/Logging and Monitoring/Logging.adoc[Logging]
-*** xref:Technical Documentation/Payara Server Documentation/Logging and Monitoring/HealthCheck Service.adoc[HealthCheck Service]
-*** xref:Technical Documentation/Payara Server Documentation/Logging and Monitoring/Payara InSight.adoc[Payara InSight]
-*** Monitoring Service
-**** xref:Technical Documentation/Payara Server Documentation/Logging and Monitoring/Monitoring Service/Basic Monitoring Configuration.adoc[Basic Monitoring Configuration]
-**** xref:Technical Documentation/Payara Server Documentation/Logging and Monitoring/Monitoring Service/JMX Monitoring.adoc[JMX Monitoring]
-**** xref:Technical Documentation/Payara Server Documentation/Logging and Monitoring/Monitoring Service/MBeans.adoc[MBeans]
-**** xref:Technical Documentation/Payara Server Documentation/Logging and Monitoring/Monitoring Service/Rest Monitoring.adoc[Rest Monitoring]
-*** Notification Service
-**** xref:Technical Documentation/Payara Server Documentation/Logging and Monitoring/Notification Service/Overview.adoc[Overview]
-**** Notifiers
-***** xref:Technical Documentation/Payara Server Documentation/Logging and Monitoring/Notification Service/Notifiers/CDI Event Bus Notifier.adoc[CDI Event Bus Notifier]
-***** xref:Technical Documentation/Payara Server Documentation/Logging and Monitoring/Notification Service/Notifiers/Custom Notifier.adoc[Custom Notifier]
-***** xref:Technical Documentation/Payara Server Documentation/Logging and Monitoring/Notification Service/Notifiers/Datadog Notifier.adoc[Datadog Notifier]
-***** xref:Technical Documentation/Payara Server Documentation/Logging and Monitoring/Notification Service/Notifiers/Discord Notifier.adoc[Discord Notifier]
-***** xref:Technical Documentation/Payara Server Documentation/Logging and Monitoring/Notification Service/Notifiers/Email Notifier.adoc[Email Notifier]
-***** xref:Technical Documentation/Payara Server Documentation/Logging and Monitoring/Notification Service/Notifiers/Event Bus Notifier.adoc[Event Bus Notifier]
-***** xref:Technical Documentation/Payara Server Documentation/Logging and Monitoring/Notification Service/Notifiers/JMS Notifier.adoc[JMS Notifier]
-***** xref:Technical Documentation/Payara Server Documentation/Logging and Monitoring/Notification Service/Notifiers/Log Notifier.adoc[Log Notifier]
-***** xref:Technical Documentation/Payara Server Documentation/Logging and Monitoring/Notification Service/Notifiers/New Relic Notifier.adoc[New Relic Notifier]
-***** xref:Technical Documentation/Payara Server Documentation/Logging and Monitoring/Notification Service/Notifiers/Slack Notifier.adoc[Slack Notifier]
-***** xref:Technical Documentation/Payara Server Documentation/Logging and Monitoring/Notification Service/Notifiers/SNMP Notifier.adoc[SNMP Notifier]
-***** xref:Technical Documentation/Payara Server Documentation/Logging and Monitoring/Notification Service/Notifiers/Teams Notifier.adoc[Teams Notifier]
-***** xref:Technical Documentation/Payara Server Documentation/Logging and Monitoring/Notification Service/Notifiers/XMPP Notifier.adoc[XMPP Notifier]
-**** JMX Monitoring Notifications
-***** xref:Technical Documentation/Payara Server Documentation/Logging and Monitoring/Notification Service/JMX Monitoring Notifications/JMX Monitoring Notifiers Asadmin Commands.adoc[JMX Monitoring Notifiers Asadmin Commands]
-***** xref:Technical Documentation/Payara Server Documentation/Logging and Monitoring/Notification Service/JMX Monitoring Notifications/JMX Monitoring Notifiers Configuration.adoc[JMX Monitoring Notifiers Configuration]
-*** Request Tracing Service
-**** xref:Technical Documentation/Payara Server Documentation/Logging and Monitoring/Request Tracing Service/Overview.adoc[Overview]
-**** xref:Technical Documentation/Payara Server Documentation/Logging and Monitoring/Request Tracing Service/Asadmin Commands.adoc[Asadmin Commands]
-**** xref:Technical Documentation/Payara Server Documentation/Logging and Monitoring/Request Tracing Service/Configuration.adoc[Configuration]
-**** xref:Technical Documentation/Payara Server Documentation/Logging and Monitoring/Request Tracing Service/Terminology.adoc[Terminology]
-**** xref:Technical Documentation/Payara Server Documentation/Logging and Monitoring/Request Tracing Service/Usage.adoc[Usage]
-** Management and Monitoring REST API
-*** xref:Technical Documentation/Payara Server Documentation/Management and Monitoring REST API/Overview.adoc[Overview]
-*** xref:Technical Documentation/Payara Server Documentation/Management and Monitoring REST API/Definitions.adoc[Definitions]
-*** xref:Technical Documentation/Payara Server Documentation/Management and Monitoring REST API/Rest API.adoc[Rest API]
+** Development Debugging And Assistance Tools
+*** xref:Technical Documentation/Payara Server Documentation/Development Debugging And Assistance Tools/CDI.adoc[CDI]
 ** Server Configuration And Management
+*** JDBC Resource Management
+**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/JDBC Resource Management/JDBC.adoc[JDBC]
+**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/JDBC Resource Management/SQL.adoc[SQL]
 *** Admin Console Enhancements
 **** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Admin Console Enhancements/Overview.adoc[Overview]
-**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Admin Console Enhancements/Asadmin Recorder.adoc[Asadmin Recorder]
 **** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Admin Console Enhancements/Auditing Service.adoc[Auditing Service]
 **** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Admin Console Enhancements/Environment Warning.adoc[Environment Warning]
-*** Application Deployment
-**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Application Deployment/Overview.adoc[Overview]
-**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Application Deployment/Concurrent CDI Bean Loading.adoc[Concurrent CDI Bean Loading]
-**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Application Deployment/Deployment Descriptors.adoc[Deployment Descriptors]
-**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Application Deployment/Descriptor Elements.adoc[Descriptor Elements]
-*** Asadmin Commands
-**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Asadmin Commands/Auto Naming.adoc[Auto Naming]
-**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Asadmin Commands/Multimode Event Designators Support.adoc[Multimode Event Designators Support]
-**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Asadmin Commands/Print Certificate Data.adoc[Print Certificate Data]
-**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Asadmin Commands/Server Management Asadmin Commands.adoc[Server Management Asadmin Commands]
+**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Admin Console Enhancements/Asadmin Recorder.adoc[Asadmin Recorder]
+*** Security Configuration
+**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Security Configuration/Overview.adoc[Overview]
+**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Security Configuration/Multiple Mechanism in EAR.adoc[Multiple Mechanism in EAR]
+**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Security Configuration/JACC.adoc[JACC]
+**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Security Configuration/JCE Provider Support.adoc[JCE Provider Support]
+**** Client Certificates
+***** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Security Configuration/Client Certificates/Custom Validators.adoc[Custom Validators]
+***** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Security Configuration/Client Certificates/Advanced Groups Configuration.adoc[Advanced Groups Configuration]
+***** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Security Configuration/Client Certificates/Advanced Principal Name Configuration.adoc[Advanced Principal Name Configuration]
+*** Thread Pools
+**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Thread Pools/EJB Thread Pool.adoc[EJB Thread Pool]
+**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Thread Pools/Default Thread Pool Size.adoc[Default Thread Pool Size]
 *** Classloading
 **** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Classloading/Overview.adoc[Overview]
-**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Classloading/Enhanced Classloading.adoc[Enhanced Classloading]
 **** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Classloading/Standard Classloading.adoc[Standard Classloading]
+**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Classloading/Enhanced Classloading.adoc[Enhanced Classloading]
+*** Application Deployment
+**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Application Deployment/Overview.adoc[Overview]
+**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Application Deployment/Descriptor Elements.adoc[Descriptor Elements]
+**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Application Deployment/Deployment Descriptors.adoc[Deployment Descriptors]
+**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Application Deployment/Concurrent CDI Bean Loading.adoc[Concurrent CDI Bean Loading]
+*** Docker Host Support
+**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Docker Host Support/Docker Nodes.adoc[Docker Nodes]
+**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Docker Host Support/Docker Instances.adoc[Docker Instances]
 *** Configuration Options
-**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Configuration Options/JVM Options.adoc[JVM Options]
 **** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Configuration Options/Password Aliases.adoc[Password Aliases]
 **** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Configuration Options/Phone Home.adoc[Phone Home]
+**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Configuration Options/JVM Options.adoc[JVM Options]
 **** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Configuration Options/Integrated Certificate Management.adoc[Integrated Certificate Management]
 **** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Configuration Options/SSL Certificates.adoc[SSL Certificates]
 **** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Configuration Options/System Properties.adoc[System Properties]
 **** Variable Substitution
-***** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Configuration Options/Variable Substitution/Types of Variables.adoc[Types of Variables]
 ***** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Configuration Options/Variable Substitution/Usage of Variables.adoc[Usage of Variables]
-*** Docker Host Support
-**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Docker Host Support/Docker Instances.adoc[Docker Instances]
-**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Docker Host Support/Docker Nodes.adoc[Docker Nodes]
-*** Domain Data Grid And Hazelcast
-**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Domain Data Grid And Hazelcast/Overview.adoc[Overview]
-**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Domain Data Grid And Hazelcast/Configuration.adoc[Configuration]
-**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Domain Data Grid And Hazelcast/Datagrid in Applications.adoc[Datagrid in Applications]
-**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Domain Data Grid And Hazelcast/Discovery.adoc[Discovery]
-**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Domain Data Grid And Hazelcast/Encryption.adoc[Encryption]
-**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Domain Data Grid And Hazelcast/Viewing Members.adoc[Viewing Members]
+***** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Configuration Options/Variable Substitution/Types of Variables.adoc[Types of Variables]
 *** HTTP Service
 **** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/HTTP Service/Overview.adoc[Overview]
-**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/HTTP Service/Network Listeners.adoc[Network Listeners]
 **** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/HTTP Service/Protocols.adoc[Protocols]
 **** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/HTTP Service/Virtual Servers.adoc[Virtual Servers]
-*** JDBC Resource Management
-**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/JDBC Resource Management/JDBC.adoc[JDBC]
-**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/JDBC Resource Management/SQL.adoc[SQL]
-*** Security Configuration
-**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Security Configuration/Overview.adoc[Overview]
-**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Security Configuration/JACC.adoc[JACC]
-**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Security Configuration/JCE Provider Support.adoc[JCE Provider Support]
-**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Security Configuration/Multiple Mechanism in EAR.adoc[Multiple Mechanism in EAR]
-**** Client Certificates
-***** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Security Configuration/Client Certificates/Advanced Groups Configuration.adoc[Advanced Groups Configuration]
-***** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Security Configuration/Client Certificates/Advanced Principal Name Configuration.adoc[Advanced Principal Name Configuration]
-***** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Security Configuration/Client Certificates/Custom Validators.adoc[Custom Validators]
-*** Thread Pools
-**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Thread Pools/Default Thread Pool Size.adoc[Default Thread Pool Size]
-**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Thread Pools/EJB Thread Pool.adoc[EJB Thread Pool]
+**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/HTTP Service/Network Listeners.adoc[Network Listeners]
+*** Asadmin Commands
+**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Asadmin Commands/Server Management Asadmin Commands.adoc[Server Management Asadmin Commands]
+**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Asadmin Commands/Multimode Event Designators Support.adoc[Multimode Event Designators Support]
+**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Asadmin Commands/Auto Naming.adoc[Auto Naming]
+**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Asadmin Commands/Print Certificate Data.adoc[Print Certificate Data]
+*** Domain Data Grid And Hazelcast
+**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Domain Data Grid And Hazelcast/Overview.adoc[Overview]
+**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Domain Data Grid And Hazelcast/Datagrid in Applications.adoc[Datagrid in Applications]
+**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Domain Data Grid And Hazelcast/Configuration.adoc[Configuration]
+**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Domain Data Grid And Hazelcast/Encryption.adoc[Encryption]
+**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Domain Data Grid And Hazelcast/Viewing Members.adoc[Viewing Members]
+**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Domain Data Grid And Hazelcast/Discovery.adoc[Discovery]
+** Deployment Groups
+*** xref:Technical Documentation/Payara Server Documentation/Deployment Groups/Overview.adoc[Overview]
+*** xref:Technical Documentation/Payara Server Documentation/Deployment Groups/Asadmin Commands.adoc[Asadmin Commands]
+*** xref:Technical Documentation/Payara Server Documentation/Deployment Groups/Timers.adoc[Timers]
+** Jakarta EE API
+*** xref:Technical Documentation/Payara Server Documentation/Jakarta EE API/JCache API.adoc[JCache API]
+*** xref:Technical Documentation/Payara Server Documentation/Jakarta EE API/JAX-WS Enhancements.adoc[JAX-WS Enhancements]
+*** xref:Technical Documentation/Payara Server Documentation/Jakarta EE API/JavaMail API.adoc[JavaMail API]
+*** JAX-RS
+**** xref:Technical Documentation/Payara Server Documentation/Jakarta EE API/JAX-RS/CDI With JAX-RS.adoc[CDI With JAX-RS]
+*** Enterprise Java Beans (EJB)
+**** xref:Technical Documentation/Payara Server Documentation/Jakarta EE API/Enterprise Java Beans (EJB)/Overview.adoc[Overview]
+**** xref:Technical Documentation/Payara Server Documentation/Jakarta EE API/Enterprise Java Beans (EJB)/Tracing Remote EJBs.adoc[Tracing Remote EJBs]
+**** xref:Technical Documentation/Payara Server Documentation/Jakarta EE API/Enterprise Java Beans (EJB)/JDK 17 Support.adoc[JDK 17 Support]
+*** JPA
+**** xref:Technical Documentation/Payara Server Documentation/Jakarta EE API/JPA/JPA Cache Coordination.adoc[JPA Cache Coordination]
+*** JSF API
+**** xref:Technical Documentation/Payara Server Documentation/Jakarta EE API/JSF API/JSF Options.adoc[JSF Options]
+*** JBatch API
+**** xref:Technical Documentation/Payara Server Documentation/Jakarta EE API/JBatch API/Overview.adoc[Overview]
+**** xref:Technical Documentation/Payara Server Documentation/Jakarta EE API/JBatch API/Schema Name.adoc[Schema Name]
+**** xref:Technical Documentation/Payara Server Documentation/Jakarta EE API/JBatch API/Table Prefix and Suffix.adoc[Table Prefix and Suffix]
+**** xref:Technical Documentation/Payara Server Documentation/Jakarta EE API/JBatch API/Database Support.adoc[Database Support]
+**** xref:Technical Documentation/Payara Server Documentation/Jakarta EE API/JBatch API/Improved Asadmin CLI.adoc[Improved Asadmin CLI]
+** Logging and Monitoring
+*** xref:Technical Documentation/Payara Server Documentation/Logging and Monitoring/Logging.adoc[Logging]
+*** xref:Technical Documentation/Payara Server Documentation/Logging and Monitoring/Payara InSight.adoc[Payara InSight]
+*** xref:Technical Documentation/Payara Server Documentation/Logging and Monitoring/HealthCheck Service.adoc[HealthCheck Service]
+*** Request Tracing Service
+**** xref:Technical Documentation/Payara Server Documentation/Logging and Monitoring/Request Tracing Service/Terminology.adoc[Terminology]
+**** xref:Technical Documentation/Payara Server Documentation/Logging and Monitoring/Request Tracing Service/Configuration.adoc[Configuration]
+**** xref:Technical Documentation/Payara Server Documentation/Logging and Monitoring/Request Tracing Service/Asadmin Commands.adoc[Asadmin Commands]
+**** xref:Technical Documentation/Payara Server Documentation/Logging and Monitoring/Request Tracing Service/Usage.adoc[Usage]
+**** xref:Technical Documentation/Payara Server Documentation/Logging and Monitoring/Request Tracing Service/Overview.adoc[Overview]
+*** Notification Service
+**** xref:Technical Documentation/Payara Server Documentation/Logging and Monitoring/Notification Service/Overview.adoc[Overview]
+**** Notifiers
+***** xref:Technical Documentation/Payara Server Documentation/Logging and Monitoring/Notification Service/Notifiers/New Relic Notifier.adoc[New Relic Notifier]
+***** xref:Technical Documentation/Payara Server Documentation/Logging and Monitoring/Notification Service/Notifiers/SNMP Notifier.adoc[SNMP Notifier]
+***** xref:Technical Documentation/Payara Server Documentation/Logging and Monitoring/Notification Service/Notifiers/Discord Notifier.adoc[Discord Notifier]
+***** xref:Technical Documentation/Payara Server Documentation/Logging and Monitoring/Notification Service/Notifiers/Custom Notifier.adoc[Custom Notifier]
+***** xref:Technical Documentation/Payara Server Documentation/Logging and Monitoring/Notification Service/Notifiers/Log Notifier.adoc[Log Notifier]
+***** xref:Technical Documentation/Payara Server Documentation/Logging and Monitoring/Notification Service/Notifiers/JMS Notifier.adoc[JMS Notifier]
+***** xref:Technical Documentation/Payara Server Documentation/Logging and Monitoring/Notification Service/Notifiers/XMPP Notifier.adoc[XMPP Notifier]
+***** xref:Technical Documentation/Payara Server Documentation/Logging and Monitoring/Notification Service/Notifiers/CDI Event Bus Notifier.adoc[CDI Event Bus Notifier]
+***** xref:Technical Documentation/Payara Server Documentation/Logging and Monitoring/Notification Service/Notifiers/Event Bus Notifier.adoc[Event Bus Notifier]
+***** xref:Technical Documentation/Payara Server Documentation/Logging and Monitoring/Notification Service/Notifiers/Slack Notifier.adoc[Slack Notifier]
+***** xref:Technical Documentation/Payara Server Documentation/Logging and Monitoring/Notification Service/Notifiers/Email Notifier.adoc[Email Notifier]
+***** xref:Technical Documentation/Payara Server Documentation/Logging and Monitoring/Notification Service/Notifiers/Teams Notifier.adoc[Teams Notifier]
+***** xref:Technical Documentation/Payara Server Documentation/Logging and Monitoring/Notification Service/Notifiers/Datadog Notifier.adoc[Datadog Notifier]
+**** JMX Monitoring Notifications
+***** xref:Technical Documentation/Payara Server Documentation/Logging and Monitoring/Notification Service/JMX Monitoring Notifications/JMX Monitoring Notifiers Asadmin Commands.adoc[JMX Monitoring Notifiers Asadmin Commands]
+***** xref:Technical Documentation/Payara Server Documentation/Logging and Monitoring/Notification Service/JMX Monitoring Notifications/JMX Monitoring Notifiers Configuration.adoc[JMX Monitoring Notifiers Configuration]
+*** Monitoring Service
+**** xref:Technical Documentation/Payara Server Documentation/Logging and Monitoring/Monitoring Service/Rest Monitoring.adoc[Rest Monitoring]
+**** xref:Technical Documentation/Payara Server Documentation/Logging and Monitoring/Monitoring Service/MBeans.adoc[MBeans]
+**** xref:Technical Documentation/Payara Server Documentation/Logging and Monitoring/Monitoring Service/JMX Monitoring.adoc[JMX Monitoring]
+**** xref:Technical Documentation/Payara Server Documentation/Logging and Monitoring/Monitoring Service/Basic Monitoring Configuration.adoc[Basic Monitoring Configuration]
+** Management and Monitoring REST API
+*** xref:Technical Documentation/Payara Server Documentation/Management and Monitoring REST API/Overview.adoc[Overview]
+*** xref:Technical Documentation/Payara Server Documentation/Management and Monitoring REST API/Rest API.adoc[Rest API]
+*** xref:Technical Documentation/Payara Server Documentation/Management and Monitoring REST API/Definitions.adoc[Definitions]
+* Ecosystem
+** xref:Technical Documentation/Ecosystem/Overview.adoc[Overview]
+** Miscellaneous
+*** xref:Technical Documentation/Ecosystem/Miscellaneous/JAX-RS Extension.adoc[JAX-RS Extension]
+** Project Management Tools
+*** xref:Technical Documentation/Ecosystem/Project Management Tools/Gradle Plugin.adoc[Gradle Plugin]
+*** xref:Technical Documentation/Ecosystem/Project Management Tools/Maven Bom.adoc[Maven Bom]
+*** xref:Technical Documentation/Ecosystem/Project Management Tools/Maven Archetype.adoc[Maven Archetype]
+*** xref:Technical Documentation/Ecosystem/Project Management Tools/Maven Plugin.adoc[Maven Plugin]
+** Connector Suites
+*** xref:Technical Documentation/Ecosystem/Connector Suites/Security Connectors.adoc[Security Connectors]
+*** Cloud Connectors
+**** xref:Technical Documentation/Ecosystem/Connector Suites/Cloud Connectors/Amazon SQS.adoc[Amazon SQS]
+**** xref:Technical Documentation/Ecosystem/Connector Suites/Cloud Connectors/Azure SB.adoc[Azure SB]
+**** xref:Technical Documentation/Ecosystem/Connector Suites/Cloud Connectors/Apache Kafka.adoc[Apache Kafka]
+**** xref:Technical Documentation/Ecosystem/Connector Suites/Cloud Connectors/MQTT.adoc[MQTT]
+**** xref:Technical Documentation/Ecosystem/Connector Suites/Cloud Connectors/Overview.adoc[Overview]
+*** Arquillian Containers
+**** xref:Technical Documentation/Ecosystem/Connector Suites/Arquillian Containers/Overview.adoc[Overview]
+**** xref:Technical Documentation/Ecosystem/Connector Suites/Arquillian Containers/Payara Micro Managed.adoc[Payara Micro Managed]
+**** xref:Technical Documentation/Ecosystem/Connector Suites/Arquillian Containers/Payara Server Remote.adoc[Payara Server Remote]
+**** xref:Technical Documentation/Ecosystem/Connector Suites/Arquillian Containers/Payara Server Managed.adoc[Payara Server Managed]
+**** xref:Technical Documentation/Ecosystem/Connector Suites/Arquillian Containers/Payara Server Embedded.adoc[Payara Server Embedded]
+** IDE Integration
+*** Eclipse Plugin
+**** xref:Technical Documentation/Ecosystem/IDE Integration/Eclipse Plugin/Overview.adoc[Overview]
+**** xref:Technical Documentation/Ecosystem/IDE Integration/Eclipse Plugin/Payara Server.adoc[Payara Server]
+**** xref:Technical Documentation/Ecosystem/IDE Integration/Eclipse Plugin/Payara Micro.adoc[Payara Micro]
+*** NetBeans Plugin
+**** xref:Technical Documentation/Ecosystem/IDE Integration/NetBeans Plugin/Overview.adoc[Overview]
+**** xref:Technical Documentation/Ecosystem/IDE Integration/NetBeans Plugin/Payara Server.adoc[Payara Server]
+**** xref:Technical Documentation/Ecosystem/IDE Integration/NetBeans Plugin/Payara Micro.adoc[Payara Micro]
+*** VSCode Extension
+**** xref:Technical Documentation/Ecosystem/IDE Integration/VSCode Extension/Overview.adoc[Overview]
+**** xref:Technical Documentation/Ecosystem/IDE Integration/VSCode Extension/Payara Server.adoc[Payara Server]
+**** xref:Technical Documentation/Ecosystem/IDE Integration/VSCode Extension/Payara Micro.adoc[Payara Micro]
+*** Intellij Plugin
+**** xref:Technical Documentation/Ecosystem/IDE Integration/Intellij Plugin/Overview.adoc[Overview]
+**** xref:Technical Documentation/Ecosystem/IDE Integration/Intellij Plugin/Payara Server.adoc[Payara Server]
+**** xref:Technical Documentation/Ecosystem/IDE Integration/Intellij Plugin/Payara Micro.adoc[Payara Micro]
+* MicroProfile
+** xref:Technical Documentation/MicroProfile/Overview.adoc[Overview]
+** xref:Technical Documentation/MicroProfile/JWT.adoc[JWT]
+** xref:Technical Documentation/MicroProfile/Rest Client.adoc[Rest Client]
+** xref:Technical Documentation/MicroProfile/OpenAPI.adoc[OpenAPI]
+** xref:Technical Documentation/MicroProfile/Fault Tolerance.adoc[Fault Tolerance]
+** xref:Technical Documentation/MicroProfile/HealthCheck.adoc[HealthCheck]
+** xref:Technical Documentation/MicroProfile/Opentracing.adoc[Opentracing]
+** Metrics
+*** xref:Technical Documentation/MicroProfile/Metrics/Metrics Rest Endpoint.adoc[Metrics Rest Endpoint]
+*** xref:Technical Documentation/MicroProfile/Metrics/Vendor Metrics.adoc[Vendor Metrics]
+*** xref:Technical Documentation/MicroProfile/Metrics/Metrics Configuration.adoc[Metrics Configuration]
+** Config
+*** xref:Technical Documentation/MicroProfile/Config/Overview.adoc[Overview]
+*** xref:Technical Documentation/MicroProfile/Config/JDBC.adoc[JDBC]
+*** xref:Technical Documentation/MicroProfile/Config/LDAP.adoc[LDAP]
+*** xref:Technical Documentation/MicroProfile/Config/Directory.adoc[Directory]
+*** Cloud
+**** xref:Technical Documentation/MicroProfile/Config/Cloud/Overview.adoc[Overview]
+**** xref:Technical Documentation/MicroProfile/Config/Cloud/GCP.adoc[GCP]
+**** xref:Technical Documentation/MicroProfile/Config/Cloud/Hashicorp.adoc[Hashicorp]
+**** xref:Technical Documentation/MicroProfile/Config/Cloud/DynamoDB.adoc[DynamoDB]
+**** xref:Technical Documentation/MicroProfile/Config/Cloud/AWS.adoc[AWS]
+**** xref:Technical Documentation/MicroProfile/Config/Cloud/Azure.adoc[Azure]
 * Public API
 ** xref:Technical Documentation/Public API/Overview.adoc[Overview]
+** xref:Technical Documentation/Public API/Roles Permitted.adoc[Roles Permitted]
 ** xref:Technical Documentation/Public API/CDI Events.adoc[CDI Events]
-** xref:Technical Documentation/Public API/Clustered Singleton.adoc[Clustered Singleton]
 ** xref:Technical Documentation/Public API/OAuth Support.adoc[OAuth Support]
 ** xref:Technical Documentation/Public API/OpenID Connect Support.adoc[OpenID Connect Support]
-** xref:Technical Documentation/Public API/Roles Permitted.adoc[Roles Permitted]
 ** xref:Technical Documentation/Public API/Security Extensions.adoc[Security Extensions]
+** xref:Technical Documentation/Public API/Clustered Singleton.adoc[Clustered Singleton]
 ** xref:Technical Documentation/Public API/Yubikey.adoc[Yubikey]
 
 include::partial$release-notes.adoc[Release Notes]
@@ -275,6 +275,6 @@ include::partial$eclipse-microprofile.adoc[Eclipse MicroProfile Certification]
 .Appendix
 * Schemas
 ** xref:Appendix/Schemas/Overview.adoc[Overview]
-** xref:Appendix/Schemas/payara-resources_1_6.dtd[payara-resources_1_6.dtd]
 ** xref:Appendix/Schemas/payara-resources_1_7.dtd[payara-resources_1_7.dtd]
 ** xref:Appendix/Schemas/payara-web-app_4.dtd[payara-web-app_4.dtd]
+** xref:Appendix/Schemas/payara-resources_1_6.dtd[payara-resources_1_6.dtd]

--- a/enterprise/docs/modules/ROOT/pages/Technical Documentation/Payara Server Documentation/Logging and Monitoring/Request Tracing Service/Overview.adoc
+++ b/enterprise/docs/modules/ROOT/pages/Technical Documentation/Payara Server Documentation/Logging and Monitoring/Request Tracing Service/Overview.adoc
@@ -1,0 +1,59 @@
+
+[[request-tracing-service]]
+= Request Tracing Service
+
+The Request Tracing Service provides tracing facilities for multiple protocols and process communications done by the components of deployed applications.
+
+The service helps users to detect application slowness and performance degradation by logging requests that exceed a given threshold. The trace data from long-running requests gives insight to solving bottlenecks and other performance issues.
+
+NOTE: The service is available in both Payara Server and Payara Micro, though the  service configuration is different in Payara Micro.
+
+The following types of requests are traced if the service is enabled:
+
+* JAX-RS endpoints
+* JAX-RS client calls
+* MicroProfile REST Client calls
+* Servlets (HTTP requests)
+* SOAP Web Services
+* WebSockets
+* EJB timers execution
+* Inbound JMS messages received by an MDB
+* JBatch jobs creation
+* Tasks executed by injected Managed Executors.
+* Remote Invocations of EJBs
+
+Starting from release 5.181, the Request Tracing Service was given an overhaul - traces are now in an OpenTracing-style format using Spans, instead of the original event stream format. Practically, this means that instead of having an ordered sequence of time stamped events constituting a trace (with separate entered and exited events), you now have a set of related traces (now called spans) with individual durations and attributes.
+
+The OpenTracing specification, found https://github.com/opentracing/specification/blob/master/specification.md[here], gives a more detailed description of what Spans are and the general trace format.
+Alternatively you can view a short summary xref:/Technical Documentation/Payara Server Documentation/Logging and Monitoring/Request Tracing Service/Terminology.adoc[here].
+
+The Request Tracing overhaul also brought in the concept of sample rates, affording you extra options to limit the amount of tracing done. In Payara 5.181, there are two offerings: flat probability, and an adaptive solution. The flat probability sampling simply applies a percentage chance that a trace will not be traced. The adaptive solution allows you to configure a target number of traces to sample over a given time period (e.g. sample 6 traces every 10 minutes).   
+
+An option to perform this sampling before or after the threshold checks is offered, allowing you to either determine if a trace should be sampled at its inception, or only after determining that a trace has breached your configured thresholds respectively.
+
+== OpenTracing Support
+
+In-line with our support for xref:/Technical Documentation/MicroProfile/Opentracing.adoc[MicroProfile OpenTracing], Payara Server & Micro have support for http://opentracing.io/[OpenTracing.io] code instrumentation.
+
+In a practical sense, this means that you can instrument your code using either the new `@Traced` annotation, or by injecting and using an OpenTracing Tracer via CDI. For full details, see the xref:/Technical Documentation/MicroProfile/Opentracing.adoc[MicroProfile OpenTracing] and https://opentracing.io/docs/[OpenTracing.io] documentation. The https://github.com/opentracing/opentracing-java/blob/release-0.30.0/Overview.md[OpenTracing Java GitHub] page also has some useful information about using the OpenTracing API.
+
+NOTE: The new MicroProfile `@Traced` annotation replaces the Payara Server & Micro specific annotation provided previously, which will require you to either remove or refactor any code instrumented with the old annotation. The new annotation's canonical name is `org.eclipse.microprofile.opentracing.Traced`.
+
+=== API Version Implemented
+
+[cols=",a", options="header"]
+|===
+|Payara Server & Micro Version
+|OpenTracing.io API Version
+| 5.36.0 - {page-version}
+| 0.33
+| 4.1.2.183 - 4.1.2.191; 5.183 - 5.35.0
+| 0.31
+| 4.1.2.182; 5.182
+| 0.30
+|===
+
+=== Features Not Currently Supported
+We currently do not offer the following OpenTracing features:
+
+* Conversion to or from OpenTracing 0.31 or newer APIs

--- a/enterprise/docs/modules/ROOT/pages/Technical Documentation/Payara Server Documentation/Logging and Monitoring/Request Tracing Service/Overview.adoc
+++ b/enterprise/docs/modules/ROOT/pages/Technical Documentation/Payara Server Documentation/Logging and Monitoring/Request Tracing Service/Overview.adoc
@@ -1,4 +1,3 @@
-
 [[request-tracing-service]]
 = Request Tracing Service
 
@@ -33,11 +32,11 @@ An option to perform this sampling before or after the threshold checks is offer
 
 == OpenTracing Support
 
-In-line with our support for xref:/Technical Documentation/MicroProfile/Opentracing.adoc[MicroProfile OpenTracing], Payara Server & Micro have support for http://opentracing.io/[OpenTracing.io] code instrumentation.
+In-line with our support for xref:/Technical Documentation/MicroProfile/Opentracing.adoc[MicroProfile OpenTracing], Payara Server and Payara Micro have support for http://opentracing.io/[OpenTracing.io] code instrumentation.
 
 In a practical sense, this means that you can instrument your code using either the new `@Traced` annotation, or by injecting and using an OpenTracing Tracer via CDI. For full details, see the xref:/Technical Documentation/MicroProfile/Opentracing.adoc[MicroProfile OpenTracing] and https://opentracing.io/docs/[OpenTracing.io] documentation. The https://github.com/opentracing/opentracing-java/blob/release-0.30.0/Overview.md[OpenTracing Java GitHub] page also has some useful information about using the OpenTracing API.
 
-NOTE: The new MicroProfile `@Traced` annotation replaces the Payara Server & Micro specific annotation provided previously, which will require you to either remove or refactor any code instrumented with the old annotation. The new annotation's canonical name is `org.eclipse.microprofile.opentracing.Traced`.
+NOTE: The new MicroProfile `@Traced` annotation replaces the Payara Server and Payara Micro specific annotation provided previously, which will require you to either remove or refactor any code instrumented with the old annotation. The new annotation's canonical name is `org.eclipse.microprofile.opentracing.Traced`.
 
 === API Version Implemented
 

--- a/enterprise/docs/modules/ROOT/pages/Technical Documentation/Payara Server Documentation/Logging and Monitoring/Request Tracing Service/Overview.adoc
+++ b/enterprise/docs/modules/ROOT/pages/Technical Documentation/Payara Server Documentation/Logging and Monitoring/Request Tracing Service/Overview.adoc
@@ -6,7 +6,7 @@ The Request Tracing Service provides tracing facilities for multiple protocols a
 
 The service helps users to detect application slowness and performance degradation by logging requests that exceed a given threshold. The trace data from long-running requests gives insight to solving bottlenecks and other performance issues.
 
-NOTE: The service is available in both Payara Server and Payara Micro, though the  service configuration is different in Payara Micro.
+NOTE: The service is available in both Payara Server and Payara Micro, though the  service configuration is different in xref:Technical Documentation/Payara Micro Documentation/Logging and Monitoring/Request Tracing.adoc[Payara Micro]
 
 The following types of requests are traced if the service is enabled:
 


### PR DESCRIPTION
Add reference to versions which use open tracing 0.33.0.

Separated the Overview page into Community and Enterprise specific pages as they refer to different version ranges.

The large Nav changes are due to the script not being fully idempotent - the script updates in #37 will alleviate that.