### PR TITLE
SERV-799 Fix dtd

### DIFF
--- a/community/docs/modules/ROOT/nav.adoc
+++ b/community/docs/modules/ROOT/nav.adoc
@@ -274,9 +274,4 @@ include::partial$eclipse-microprofile.adoc[Eclipse MicroProfile Certification]
 * xref:Security/Overview.adoc[Overview]
 * xref:Security/Security Fix List.adoc[Security Fix List]
 
-.Appendix
-* Schemas
-** xref:Appendix/Schemas/Overview.adoc[Overview]
-** xref:Appendix/Schemas/payara-resources_1_6.dtd[payara-resources_1_6.dtd]
-** xref:Appendix/Schemas/payara-resources_1_7.dtd[payara-resources_1_7.dtd]
-** xref:Appendix/Schemas/payara-web-app_4.dtd[payara-web-app_4.dtd]
+include::partial$appendix.adoc[Appendix]

--- a/community/docs/modules/ROOT/partials/appendix.adoc
+++ b/community/docs/modules/ROOT/partials/appendix.adoc
@@ -1,0 +1,6 @@
+.Appendix
+* Schemas
+** xref:Appendix/Schemas/Overview.adoc[Overview]
+** https://raw.githubusercontent.com/AlanRoth/Payara-Documentation/master/docs/modules/ROOT/pages/Appendix/Schemas/payara-resources_1_6.dtd[payara-resources_1_6.dtd]
+** https://raw.githubusercontent.com/AlanRoth/Payara-Documentation/master/docs/modules/ROOT/pages/Appendix/Schemas/payara-resources_1_7.dtd[payara-resources_1_7.dtd]
+** https://raw.githubusercontent.com/AlanRoth/Payara-Documentation/master/docs/modules/ROOT/pages/Appendix/Schemas/payara-web-app_4.dtd[payara-web-app_4.dtd]

--- a/community/docs/modules/ROOT/partials/appendix.adoc
+++ b/community/docs/modules/ROOT/partials/appendix.adoc
@@ -1,6 +1,5 @@
 .Appendix
 * Schemas
 ** xref:Appendix/Schemas/Overview.adoc[Overview]
-** https://raw.githubusercontent.com/AlanRoth/Payara-Documentation/master/docs/modules/ROOT/pages/Appendix/Schemas/payara-resources_1_6.dtd[payara-resources_1_6.dtd]
-** https://raw.githubusercontent.com/AlanRoth/Payara-Documentation/master/docs/modules/ROOT/pages/Appendix/Schemas/payara-resources_1_7.dtd[payara-resources_1_7.dtd]
-** https://raw.githubusercontent.com/AlanRoth/Payara-Documentation/master/docs/modules/ROOT/pages/Appendix/Schemas/payara-web-app_4.dtd[payara-web-app_4.dtd]
+** link:{payaraResourcesDtd}[DTD for payara-resources.xml]
+** link:{payaraWebDtd}[DTD for payara-web.xml]

--- a/enterprise/docs/modules/ROOT/nav.adoc
+++ b/enterprise/docs/modules/ROOT/nav.adoc
@@ -274,9 +274,4 @@ include::partial$eclipse-microprofile.adoc[Eclipse MicroProfile Certification]
 * xref:Security/Overview.adoc[Overview]
 * xref:Security/Security Fix List.adoc[Security Fix List]
 
-.Appendix
-* Schemas
-** xref:Appendix/Schemas/Overview.adoc[Overview]
-** xref:Appendix/Schemas/payara-resources_1_6.dtd[payara-resources_1_6.dtd]
-** xref:Appendix/Schemas/payara-resources_1_7.dtd[payara-resources_1_7.dtd]
-** xref:Appendix/Schemas/payara-web-app_4.dtd[payara-web-app_4.dtd]
+include::partial$appendix.adoc[Appendix]

--- a/enterprise/docs/modules/ROOT/partials/appendix.adoc
+++ b/enterprise/docs/modules/ROOT/partials/appendix.adoc
@@ -1,0 +1,6 @@
+.Appendix
+* Schemas
+** xref:Appendix/Schemas/Overview.adoc[Overview]
+** https://raw.githubusercontent.com/AlanRoth/Payara-Documentation/master/docs/modules/ROOT/pages/Appendix/Schemas/payara-resources_1_6.dtd[payara-resources_1_6.dtd]
+** https://raw.githubusercontent.com/AlanRoth/Payara-Documentation/master/docs/modules/ROOT/pages/Appendix/Schemas/payara-resources_1_7.dtd[payara-resources_1_7.dtd]
+** https://raw.githubusercontent.com/AlanRoth/Payara-Documentation/master/docs/modules/ROOT/pages/Appendix/Schemas/payara-web-app_4.dtd[payara-web-app_4.dtd]

--- a/enterprise/docs/modules/ROOT/partials/appendix.adoc
+++ b/enterprise/docs/modules/ROOT/partials/appendix.adoc
@@ -1,6 +1,5 @@
 .Appendix
 * Schemas
 ** xref:Appendix/Schemas/Overview.adoc[Overview]
-** https://raw.githubusercontent.com/AlanRoth/Payara-Documentation/master/docs/modules/ROOT/pages/Appendix/Schemas/payara-resources_1_6.dtd[payara-resources_1_6.dtd]
-** https://raw.githubusercontent.com/AlanRoth/Payara-Documentation/master/docs/modules/ROOT/pages/Appendix/Schemas/payara-resources_1_7.dtd[payara-resources_1_7.dtd]
-** https://raw.githubusercontent.com/AlanRoth/Payara-Documentation/master/docs/modules/ROOT/pages/Appendix/Schemas/payara-web-app_4.dtd[payara-web-app_4.dtd]
+** link:{payaraResourcesDtd}[DTD for payara-resources.xml]
+** link:{payaraWebDtd}[DTD for payara-web.xml]

--- a/generate-nav.py
+++ b/generate-nav.py
@@ -29,7 +29,8 @@ NAV_PATH = DOCS_PREFIX + f"nav{FILE_EXTENSION}"
 LAYOUT_FILE = "nav.layout"
 PARTIALS = {"Jakarta EE Certification":f"jakarta-ee{FILE_EXTENSION}",
     "Eclipse MicroProfile Certification":f"eclipse-microprofile{FILE_EXTENSION}",
-    "Release Notes":f"release-notes{FILE_EXTENSION}"}
+    "Release Notes":f"release-notes{FILE_EXTENSION}",
+    "Appendix":f"appendix{FILE_EXTENSION}"}
 
 DISTRIBUTIONS = ['enterprise/', 'community/']
 


### PR DESCRIPTION
- Place Appendix into Partial file (To stop it being generated automatically - the only updates required now will be in the antora.yml)
- Utilize the antora.yml attributes (Less redundancy)

We initially introduced a rewrite rule with Apache, which has been broken since Phase-1, the overview has been using the antora.yml attributes which is less fragile and easier to update, this just standardizes it to all parts.

