### PR TITLE
Fix matching for 'ord' when creating xfiles

### DIFF
--- a/community/docs/modules/ROOT/nav.adoc
+++ b/community/docs/modules/ROOT/nav.adoc
@@ -12,6 +12,7 @@
 ** Server Configuration And Management
 *** Admin Console Enhancements
 **** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Admin Console Enhancements/Overview.adoc[Overview]
+**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Admin Console Enhancements/Asadmin Recorder.adoc[Asadmin Recorder]
 **** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Admin Console Enhancements/Auditing Service.adoc[Auditing Service]
 **** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Admin Console Enhancements/Environment Warning.adoc[Environment Warning]
 *** Application Deployment
@@ -36,6 +37,7 @@
 **** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Concurrency Enhancements/Configuring Managed Thread Factories.adoc[Configuring Managed Thread Factories]
 *** Configuration Options
 **** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Configuration Options/JVM Options.adoc[JVM Options]
+**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Configuration Options/Password Aliases.adoc[Password Aliases]
 **** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Configuration Options/Phone Home.adoc[Phone Home]
 **** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Configuration Options/SSL Certificates.adoc[SSL Certificates]
 **** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Configuration Options/System Properties.adoc[System Properties]
@@ -112,6 +114,7 @@
 **** xref:Technical Documentation/Payara Server Documentation/Jakarta EE API/JBatch API/Table Prefix and Suffix.adoc[Table Prefix and Suffix]
 *** xref:Technical Documentation/Payara Server Documentation/Jakarta EE API/JCache API.adoc[JCache API]
 *** JPA
+**** xref:Technical Documentation/Payara Server Documentation/Jakarta EE API/JPA/JPA Cache Coordination.adoc[JPA Cache Coordination]
 *** JSF API
 **** xref:Technical Documentation/Payara Server Documentation/Jakarta EE API/JSF API/JSF Options.adoc[JSF Options]
 *** xref:Technical Documentation/Payara Server Documentation/Jakarta EE API/JavaMail API.adoc[JavaMail API]
@@ -131,6 +134,7 @@
 **** xref:Technical Documentation/Payara Server Documentation/Extensions/Notifiers/Overview.adoc[Overview]
 **** xref:Technical Documentation/Payara Server Documentation/Extensions/Notifiers/Custom Notifiers.adoc[Custom Notifiers]
 **** xref:Technical Documentation/Payara Server Documentation/Extensions/Notifiers/Datadog.adoc[Datadog]
+**** xref:Technical Documentation/Payara Server Documentation/Extensions/Notifiers/Discord.adoc[Discord]
 **** xref:Technical Documentation/Payara Server Documentation/Extensions/Notifiers/Email.adoc[Email]
 **** xref:Technical Documentation/Payara Server Documentation/Extensions/Notifiers/MS Teams.adoc[MS Teams]
 **** xref:Technical Documentation/Payara Server Documentation/Extensions/Notifiers/New Relic.adoc[New Relic]

--- a/enterprise/docs/modules/ROOT/nav.adoc
+++ b/enterprise/docs/modules/ROOT/nav.adoc
@@ -10,6 +10,7 @@
 ** Server Configuration And Management
 *** Admin Console Enhancements
 **** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Admin Console Enhancements/Overview.adoc[Overview]
+**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Admin Console Enhancements/Asadmin Recorder.adoc[Asadmin Recorder]
 **** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Admin Console Enhancements/Auditing Service.adoc[Auditing Service]
 **** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Admin Console Enhancements/Environment Warning.adoc[Environment Warning]
 *** Application Deployment
@@ -35,6 +36,7 @@
 *** Configuration Options
 **** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Configuration Options/Integrated Certificate Management.adoc[Integrated Certificate Management]
 **** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Configuration Options/JVM Options.adoc[JVM Options]
+**** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Configuration Options/Password Aliases.adoc[Password Aliases]
 **** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Configuration Options/Phone Home.adoc[Phone Home]
 **** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Configuration Options/SSL Certificates.adoc[SSL Certificates]
 **** xref:Technical Documentation/Payara Server Documentation/Server Configuration And Management/Configuration Options/System Properties.adoc[System Properties]
@@ -93,6 +95,7 @@
 ***** xref:Technical Documentation/Payara Server Documentation/Logging and Monitoring/Notification Service/Notifiers/CDI Event Bus Notifier.adoc[CDI Event Bus Notifier]
 ***** xref:Technical Documentation/Payara Server Documentation/Logging and Monitoring/Notification Service/Notifiers/Custom Notifier.adoc[Custom Notifier]
 ***** xref:Technical Documentation/Payara Server Documentation/Logging and Monitoring/Notification Service/Notifiers/Datadog Notifier.adoc[Datadog Notifier]
+***** xref:Technical Documentation/Payara Server Documentation/Logging and Monitoring/Notification Service/Notifiers/Discord Notifier.adoc[Discord Notifier]
 ***** xref:Technical Documentation/Payara Server Documentation/Logging and Monitoring/Notification Service/Notifiers/Email Notifier.adoc[Email Notifier]
 ***** xref:Technical Documentation/Payara Server Documentation/Logging and Monitoring/Notification Service/Notifiers/Event Bus Notifier.adoc[Event Bus Notifier]
 ***** xref:Technical Documentation/Payara Server Documentation/Logging and Monitoring/Notification Service/Notifiers/JMS Notifier.adoc[JMS Notifier]
@@ -124,6 +127,7 @@
 **** xref:Technical Documentation/Payara Server Documentation/Jakarta EE API/JBatch API/Table Prefix and Suffix.adoc[Table Prefix and Suffix]
 *** xref:Technical Documentation/Payara Server Documentation/Jakarta EE API/JCache API.adoc[JCache API]
 *** JPA
+**** xref:Technical Documentation/Payara Server Documentation/Jakarta EE API/JPA/JPA Cache Coordination.adoc[JPA Cache Coordination]
 *** JSF API
 **** xref:Technical Documentation/Payara Server Documentation/Jakarta EE API/JSF API/JSF Options.adoc[JSF Options]
 *** xref:Technical Documentation/Payara Server Documentation/Jakarta EE API/JavaMail API.adoc[JavaMail API]

--- a/generate-nav.py
+++ b/generate-nav.py
@@ -170,7 +170,7 @@ def get_xfiles(parent:Xdirectory, distribution: str) -> _Xobject:
             if os.path.isdir(filepath):
                 xobject = get_xfiles(Xdirectory(parent, filepath), distribution)
             elif os.path.isfile(filepath):
-                if "ord" not in filepath:
+                if not bool(re.search(r"\.ord\d+", filepath)):
                     xobject = Xfile(parent, filepath, file, distribution)
 
             if xobject:


### PR DESCRIPTION
"ord" was being matched in every file path and hence skipped if true, mistake in trying to skip 'ord' files. Using regex fixes the issue.