### PR TITLE
SERV-840 Add FISH-5976 To Release Notes (5.42.0)

### DIFF
--- a/enterprise/docs/modules/ROOT/pages/Release Notes/Release Notes 5.40.0.adoc
+++ b/enterprise/docs/modules/ROOT/pages/Release Notes/Release Notes 5.40.0.adoc
@@ -20,6 +20,8 @@
 
 [FISH-1515] Connection Closes Prematurely On HTTP/2 HTTPS Connections When Request Takes Long To Complete
 
+[FISH-5976] Trying To Access Microprofile Config Before Service Locator Started During Postboot Script
+
 ### Component Upgrades
 
 [FISH-6263] Smack 4.3.4


### PR DESCRIPTION
FISH-5976 was marked as done without any fix versions and so is not present in the release notes.