### PR TITLE
SERV-841 Document Password Aliases Not Trimming Whitespace

### DIFF
--- a/docs/modules/ROOT/pages/Technical Documentation/Payara Server Documentation/Server Configuration And Management/Configuration Options/Password Aliases.adoc
+++ b/docs/modules/ROOT/pages/Technical Documentation/Payara Server Documentation/Server Configuration And Management/Configuration Options/Password Aliases.adoc
@@ -5,6 +5,8 @@ By default, passwords within Payara Server are treated like any other property a
 
 A *password alias* allows you to have a plaintext reference to an encrypted password stored on the server, with the alias being used wherever the password is needed.
 
+NOTE: Password aliases do not trim leading or trailing whitespace, they are exactly as you input them via the Admin Console, CLI or password file.
+
 [[using-password-alias-admin-console]]
 == Using a password alias within the Admin Console
 


### PR DESCRIPTION
As mentioned in https://github.com/payara/Payara/issues/5887 it's not documented anywhere that password aliases don't trim whitespace. 