### PR TITLE
Fixes to getting started section and added missing page on Enterprise

### DIFF
--- a/community/docs/modules/ROOT/pages/General Info/Getting Started.adoc
+++ b/community/docs/modules/ROOT/pages/General Info/Getting Started.adoc
@@ -28,7 +28,7 @@ To start Payara Server, execute the following command:
 $ {PAYARA_INSTALL_DIR}/bin/asadmin start-domain
 ----
 
-This will start **domain1** domain, which is the default domain included with Payara Server. If you wanted to start a different domain, the domain name would need to be specified. An example can be seen below:
+This will start `domain1`, which is the default domain included with Payara Server. If you wanted to start a different domain, the domain name would need to be specified. An example can be seen below:
 
 [source, shell]
 ----
@@ -48,7 +48,7 @@ In order for a web application to run, it must be first deployed on an applicati
 [[deploying-using-asadmin]]
 === Deploying using Asadmin
 
-To deploy a WAR file, you need to use the `deploy option`, followed by the path to the application to deploy. See below for an example of deploying a WAR file:
+To deploy a WAR file, you need to use the `deploy` option, followed by the path to the application to deploy. See below for an example of deploying a WAR file:
 
 [source, shell]
 ----

--- a/enterprise/docs/modules/ROOT/nav.adoc
+++ b/enterprise/docs/modules/ROOT/nav.adoc
@@ -1,6 +1,7 @@
 
 .General Info
 * xref:General Info/Overview.adoc[Overview]
+* xref:General Info/Getting Started.adoc[Getting Started]
 * xref:General Info/Supported Platforms.adoc[Supported Platforms]
 * xref:General Info/Support Integration.adoc[Support Integration]
 

--- a/enterprise/docs/modules/ROOT/pages/General Info/Getting Started.adoc
+++ b/enterprise/docs/modules/ROOT/pages/General Info/Getting Started.adoc
@@ -9,7 +9,7 @@ Visit our https://www.payara.fish/learn/getting-started-with-payara/[Getting Sta
 [[downloading-payara-server]]
 == Downloading Payara Server
 
-Payara Server can be downloaded from http://www.payara.fish/downloads[the Payara Platform official website]. Download the ZIP bundle to a directory of your choosing and then unzip. On Linux based systems you can use the following command:
+Payara Server can be downloaded from our official Nexus Enterprise repositories by using your subscription organizational credentials. Read this knowledge base article for more information. Download the ZIP bundle to a directory of your choosing and then unzip. On Linux based systems you can use the following command:
 
 [source, shell, subs=attributes+]
 ----

--- a/enterprise/docs/modules/ROOT/pages/General Info/Getting Started.adoc
+++ b/enterprise/docs/modules/ROOT/pages/General Info/Getting Started.adoc
@@ -28,7 +28,7 @@ To start Payara Server, execute the following command:
 $ {PAYARA_INSTALL_DIR}/bin/asadmin start-domain
 ----
 
-This will start **domain1** domain, which is the default domain included with Payara Server. If you wanted to start a different domain, the domain name would need to be specified. An example can be seen below:
+This will start `domain1`, which is the default domain included with Payara Server. If you wanted to start a different domain, the domain name would need to be specified. An example can be seen below:
 
 [source, shell]
 ----
@@ -48,7 +48,7 @@ In order for a web application to run, it must be first deployed on an applicati
 [[deploying-using-asadmin]]
 === Deploying using Asadmin
 
-To deploy a WAR file, you need to use the `deploy option`, followed by the path to the application to deploy. See below for an example of deploying a WAR file:
+To deploy a WAR file, you need to use the `deploy` option, followed by the path to the application to deploy. See below for an example of deploying a WAR file:
 
 [source, shell]
 ----

--- a/enterprise/docs/modules/ROOT/pages/General Info/Support Integration.adoc
+++ b/enterprise/docs/modules/ROOT/pages/General Info/Support Integration.adoc
@@ -1,6 +1,6 @@
 [[support-integration]]
 = Support Integration
-:ordinal: 2
+:ordinal: 3
 
 IMPORTANT: This feature is un-supported and no longer works in Payara Server.
 

--- a/enterprise/docs/modules/ROOT/pages/General Info/Supported Platforms.adoc
+++ b/enterprise/docs/modules/ROOT/pages/General Info/Supported Platforms.adoc
@@ -1,5 +1,5 @@
 = Supported Platforms
-:ordinal: 1
+:ordinal: 2
 
 Though it is always possible for new versions to be supported, this page details the JVMs currently supported by the Payara Platform (both Payara Server and Payara Micro).
 


### PR DESCRIPTION
Minor fixes to the Getting Started page, and added missing page to the Enterprise component.

This PR has to be replicated in existing branches for `5.43.0` and `5.2022.3`