### PR TITLE
SERV-876 (P6) Update Considerations for Payara 6

### DIFF
--- a/community/docs/modules/ROOT/pages/Technical Documentation/Payara Server Documentation/Upgrade Payara/Backup and Restore Method.adoc
+++ b/community/docs/modules/ROOT/pages/Technical Documentation/Payara Server Documentation/Upgrade Payara/Backup and Restore Method.adoc
@@ -28,14 +28,14 @@ asadmin> backup-domain --backupDir /home/james/payarabackup --long domain1
 Backed up domain1 at Tue Jul 05 13:48:54 BST 2022.
 
 Description               : domain1 backup created on 2022_07_05 by user james
-GlassFish Version         : Payara Server  5.2022.1 #badassfish (build 880)
+GlassFish Version         : Payara Server  6 #badassfish (build 880)
 Backup User               : james
 Backup Date               : Tue Jul 05 13:48:54 BST 2022
 Domain Name               : domain1
 Backup Type               : full
 Backup Config Name        :
 Backup Filename (origin)  : /home/james/payarabackup/domain1/domain1_2022_07_05_v00002.zip
-Domain Directory          : /home/james/5.2022.1/payara5/glassfish/domains/domain1
+Domain Directory          : /home/james/6.2022.1/payara6/glassfish/domains/domain1
 
 Command backup-domain executed successfully.
 ----
@@ -58,17 +58,17 @@ You can get additional details of the restore operation by using the `--long` ar
 ----
 asadmin> restore-domain --filename /home/james/payarabackup/domain1/domain1_2022_07_04_v00001.zip --long domain1
 
-Restored the domain (domain1) to /home/james/5.2022.2/payara5/glassfish/domains/domain1
+Restored the domain (domain1) to /home/james/6.2021.1/payara6/glassfish/domains/domain1
 
 Description               : domain1 backup created on 2022_07_05 by user james
-GlassFish Version         : Payara Server  5.2022.1 #badassfish (build 880)
+GlassFish Version         : Payara Server  6 #badassfish (build 880)
 Backup User               : james
 Backup Date               : Tue Jul 05 13:48:54 BST 2022
 Domain Name               : domain1
 Backup Type               : full
 Backup Config Name        :
 Backup Filename (origin)  : /home/james/payarabackup/domain1/domain1_2022_07_05_v00001.zip
-Domain Directory          : /home/james/5.2022.1/payara5/glassfish/domains/domain1
+Domain Directory          : /home/james/6.2021.1.Alpha3/payara6/glassfish/domains/domain1
 
 Command restore-domain executed successfully.
 ----
@@ -80,7 +80,7 @@ xref:Technical Documentation/Payara Server Documentation/Server Configuration An
 Since all data in an instance directory is kept in sync with the DAS, there is no added data (besides logs, caches and some MQ data when a file-based store is used) and an instance can be completely restored simply by making sure there is an empty directory with the name of the instance inside a node folder of the correct name.
 
 For example:
-`payara5/glassfish/nodes/localhost-example/myInstance`
+`payara6/glassfish/nodes/localhost-example/myInstance`
 
 Running the `start-local-instance` command with the `sync` property set to `full` sync, will restore the instance completely:
 

--- a/community/docs/modules/ROOT/pages/Technical Documentation/Payara Server Documentation/Upgrade Payara/Domain and Node Directories Method.adoc
+++ b/community/docs/modules/ROOT/pages/Technical Documentation/Payara Server Documentation/Upgrade Payara/Domain and Node Directories Method.adoc
@@ -2,22 +2,22 @@
 = Domain and Node Directories Upgrade Method
 :ordinal: 2
 
-An alternative to backing up and restoring the domain, then recreating the instances, would be to create the domain and node directories in a location separate to the installation. For example, if you download _Payara Server 5.2021.10_, created a domain, and then wanted to use _Payara Server 5.2022.2_, you would use the following process:
+An alternative to backing up and restoring the domain, then recreating the instances, would be to create the domain and node directories in a location separate to the installation. For example, if you download _Payara Server 6.2022.1.Alpha3_, created a domain, and then wanted to use _Payara Server 6.2022.1_, you would use the following process:
 
 [source, shell]
 ----
-/opt/payara/payara-5.2021.10/payara5 bin/asadmin create-domain --domaindir /tmp myTempDomain
-/opt/payara/payara-5.2021.10/payara5 cd ../../payara-5.2021.10/payara5
-/opt/payara/payara-5.2022.2/payara5 bin/asadmin start-domain --domaindir /tmp myTempDomain
+/opt/payara/payara-6.2022.1.Alpha3/payara6 bin/asadmin create-domain --domaindir /tmp myTempDomain
+/opt/payara/payara-6.2022.1.Alpha3/payara6 cd ../../payara-6.2022.1.Alpha3/payara6
+/opt/payara/payara-6.2022.1/payara6 bin/asadmin start-domain --domaindir /tmp myTempDomain
 ----
 
-This will use the _5.2021.10_ installation to create a new domain, and then run it with the _5.2022.2_ installation.
+This will use the _6.2022.1.Alpha3_ installation to create a new domain, and then run it with the _6.2022.1_ installation.
 
 Nodes can also be created in a separate directory by using the `--nodedir` property when creating a node.
 
 [source, shell]
 ----
-/opt/payara/payara-5.2021.10/payara5 bin/asadmin create-node --nodedir /tmp myLocalNode
+/opt/payara/payara-6.2022.1.Alpha3/payara6 bin/asadmin create-node --nodedir /tmp myLocalNode
 ----
 
 In this way, the user configuration is always kept separate to the installation, and rollback is as simple as using the previous installation directory.
@@ -29,27 +29,27 @@ This means that any rollback is as simple as stopping the server, updating a sym
 If you choose not to use symbolic links, the asadmin start-domain subcommand has a `--domaindir` option which allows you to specify the location of a domain directory. So you could have a directory structure like the following:
 
 ----
-/opt/payara/5.2021.10/payara5/...
-/opt/payara/5.2022.1/payara5/...
-/opt/payara/5.2022.2/payara5/....
+/opt/payara/6.2022.1.Alpha3/payara6/...
+/opt/payara/6.2022.1.Alpha4/payara6/...
+/opt/payara/6.2022.1/payara6/....
 /opt/payara/domains/myDomain
 /opt/payara/nodes/myLocalNode
 ----
 
-Then you could start your domain with whatever version of Payara Server you wanted by running the  tart-domain command from the corresponding Payara installation directory.
+Then you could start your domain with whatever version of Payara Server you wanted by running the start-domain command from the corresponding Payara installation directory.
 
 [source, shell]
 ----
-/opt/payara/5.2021.10/payara5/bin/asadmin start-domain --domaindir /opt/payara/domains myDomain
-/opt/payara/5.2022.1/payara5/bin/asadmin start-domain --domaindir /opt/payara/domains myDomain
-/opt/payara/5.2022.2/payara5/bin/asadmin start-domain --domaindir /opt/payara/domains myDomain
+/opt/payara/6.2022.1.Alpha3/payara6/bin/asadmin start-domain --domaindir /opt/payara/domains myDomain
+/opt/payara/6.2022.1.Alpha4/payara6/bin/asadmin start-domain --domaindir /opt/payara/domains myDomain
+/opt/payara/6.2022.1/payara6/bin/asadmin start-domain --domaindir /opt/payara/domains myDomain
 ----
 
 Just as you can create nodes by using the `--domaindir` property, you can also start nodes in the same way.
 
 [source, shell]
 ----
-/opt/payara/5.2021.10/payara5/bin/asadmin start-local-instance --nodedir /opt/payara/nodes myLocalNode
-/opt/payara/5.2022.1/payara5/bin/asadmin start-local-instance --nodedir /opt/payara/nodes myLocalNode
-/opt/payara/5.2022.2/payara5/bin/asadmin start-local-instance --nodedir /opt/payara/nodes myLocalNode
+/opt/payara/6.2022.1.Alpha3/payara6/bin/asadmin start-local-instance --nodedir /opt/payara/nodes myLocalNode
+/opt/payara/6.2022.1.Alpha4/payara6/bin/asadmin start-local-instance --nodedir /opt/payara/nodes myLocalNode
+/opt/payara/6.2022.1/payara6/bin/asadmin start-local-instance --nodedir /opt/payara/nodes myLocalNode
 ----

--- a/community/docs/modules/ROOT/pages/Technical Documentation/Payara Server Documentation/Upgrade Payara/Overview.adoc
+++ b/community/docs/modules/ROOT/pages/Technical Documentation/Payara Server Documentation/Upgrade Payara/Overview.adoc
@@ -3,60 +3,10 @@
 
 There are two valid methods of fully upgrading to a new release of Payara Community Edition. Either of the following two methods would work in most circumstances:
 
+IMPORTANT: These methods should not be used for upgrading from Payara 5 to Payara 6 and will not update your installation correctly. You should instead use a clean install of Payara 6
+
 . Backing up and restoring the existing configuration to a new installation.
 xref:Technical Documentation/Payara Server Documentation/Upgrade Payara/Backup and Restore Method.adoc[Read Backup and Restore Method]
 
 . Maintaining completely separate domain and node directories and pointing the new version to the existing directories.
 xref:Technical Documentation/Payara Server Documentation/Upgrade Payara/Domain and Node Directories Method.adoc[Read Domain and Node Directories Method]
-
-[[jdk-11-upgrade-considerations]]
-== JDK 11: Upgrade Considerations
-
-IMPORTANT: Applies when upgrading to Payara Server 5.192 and superior releases
-
-The `domain.xml` configuration file contains instructions for handling JDK 11. Without these instructions, Payara Server will not start up on JDK 11 and/or will throw many exceptions during runtime.
-
-If older, pre-5.192, domains are being migrated to Payara Server 5.192 or above, this has to be taken into account. The following `jvm-options` have to be added to the `java-config` element in `domain.xml`:
-
-[source, xml]
-----
-<jvm-options>[9|]--add-opens=java.base/jdk.internal.loader=ALL-UNNAMED</jvm-options>
-<jvm-options>[9|]--add-opens=jdk.management/com.sun.management.internal=ALL-UNNAMED</jvm-options>
-<jvm-options>[9|]--add-exports=java.base/jdk.internal.ref=ALL-UNNAMED</jvm-options>
-<jvm-options>[9|]--add-opens=java.base/java.lang=ALL-UNNAMED</jvm-options>
-<jvm-options>[9|]--add-opens=java.base/java.nio=ALL-UNNAMED</jvm-options>
-<jvm-options>[9|]--add-opens=java.base/sun.nio.ch=ALL-UNNAMED</jvm-options>
-<jvm-options>[9|]--add-opens=java.management/sun.management=ALL-UNNAMED</jvm-options>
-<jvm-options>[9|]--add-opens=java.base/sun.net.www.protocol.jrt=ALL-UNNAMED</jvm-options>
-<jvm-options>[9|]-Xbootclasspath/a:${com.sun.aas.installRoot}/lib/grizzly-npn-api.jar</jvm-options>
-----
-
-The following `jvm-options` have to be removed:
-
-[source, xml]
-----
-<jvm-options>-Djava.endorsed.dirs=${com.sun.aas.installRoot}/modules/endorsed${path.separator}${com.sun.aas.installRoot}/lib/endorsed</jvm-options>
-<jvm-options>-Djava.ext.dirs=${com.sun.aas.javaRoot}/lib/ext${path.separator}${com.sun.aas.javaRoot}/jre/lib/ext${path.separator}${com.sun.aas.instanceRoot}/lib/ext</jvm-options>
-----
-
----
-
-[[jdk-17-upgrade-considerations]]
-== JDK 17: Upgrade Considerations
-
-IMPORTANT: Applies when upgrading to Payara Community 5.2021.9 and superior releases
-
-The `domain.xml` configuration file contains instructions for handling JDK 17. Without these instructions, Payara Server will not start up on JDK 17 and/or will throw many exceptions during runtime.
-
-If older, pre-5.192, domains are being upgraded, follow the JDK 11 upgrade considerations steps first, then come back to the JDK 17 upgrade considerations.
-
-If older, pre-5.2021.9, domains are being upgraded to Payara Server 5.2021.9 or above, this has to be taken into account. The following `jvm-options` have to be added to the `java-config` element in `domain.xml`:
-
-[source, xml]
-----
-<jvm-options>[17|]--add-exports=java.base/sun.net.www=ALL-UNNAMED</jvm-options>
-<jvm-options>[17|]--add-exports=java.base/sun.security.util=ALL-UNNAMED</jvm-options>
-<jvm-options>[17|]--add-opens=java.base/java.lang.invoke=ALL-UNNAMED</jvm-options>
-<jvm-options>[17|]--add-opens=java.desktop/java.beans=ALL-UNNAMED</jvm-options>
-<jvm-options>[17|]--add-exports=jdk.naming.dns/com.sun.jndi.dns=ALL-UNNAMED</jvm-options>
-----


### PR DESCRIPTION
Changes references to Payara 5 -> Payara 6. No changes applied to Enterprise docs here as the version number is unknown and the upgrade methods will be different.

Removed JDK 11 and 17 upgrade considerations and all Payara 6 distributions available will contain everything for JDK 11 & 17