### PR TITLE
FISH-372 Document Option to Disable Clustering Functionality of Hazelcast on Payara Micro

### DIFF
--- a/community/docs/modules/ROOT/pages/Technical Documentation/Payara Micro Documentation/Payara Micro Docker Image.adoc
+++ b/community/docs/modules/ROOT/pages/Technical Documentation/Payara Micro Documentation/Payara Micro Docker Image.adoc
@@ -174,12 +174,25 @@ Payara Micro will start in "clustering" mode by booting up the xref:/Technical D
 
 The Data Grid initialization and maintenance consumes extra resources, so in cases where clustering is not needed, it is recommended to disable the Data Grid completely.
 
-To disable the Data Grid, you can pass the `--noCluster` argument to the entry point of the run command:
+To disable the Data Grid, you can pass the `--noHazelcast` argument to the entry point of the run command:
 
 [source, shell]
 ----
-docker run -p 8080:8080 \
- -v ~/payara-micro/applications:/opt/payara/deployments payara/micro --noCluster
+docker run -p 8080:8080 -v ~/payara-micro/applications:/opt/payara/deployments payara/micro --noHazelcast
+----
+
+[[disabling-clustering]]
+=== Disable Clustering
+
+By default, Payara Micro will start with hazelcast enabled, allowing other instances reachable in the network to join the datagrid automatically and cluster.
+
+Disabling hazelcast with the <<disabling-data-grid, --noHazelcast>> option will also disable all features that depend on Hazelcast, including JCache. The `--noCluster` option allows you to keep Hazelcast and therefore all features depending on Hazelcast, but disable clustering. This will significantly improve performance and is the recommended option if you require Hazelcast dependant features, but do not intend to use clustering.
+
+To disable clustering, you can pass the `--noCluster` argument to the entry point of the run command:
+
+[source, shell]
+----
+docker run -p 8080:8080 -v ~/payara-micro/applications:/opt/payara/deployments payara/micro --noCluster
 ----
 
 [[using-environment-variables]]

--- a/docs/modules/ROOT/pages/Technical Documentation/Payara Micro Documentation/Payara Micro Configuration and Management/Micro Management/Command Line Options/Command Line Options.adoc
+++ b/docs/modules/ROOT/pages/Technical Documentation/Payara Micro Documentation/Payara Micro Configuration and Management/Micro Management/Command Line Options/Command Line Options.adoc
@@ -113,6 +113,8 @@ _(Adjective-Fish)_.
 |Do not unpack the Nested Jars when booting the server. This is generally slower
 than unpacking the runtime.| _false_
 |`--nocluster`
+|Disables clustering for this instance.| _false_
+|`--noHazelcast`
 |Disables Hazelcast and clustering for this instance.| _false_
 |`--nohostaware`|Disables Host Aware Partitioning. See `--hostaware`|
 |`--outputuberjar <file-path>`

--- a/docs/modules/ROOT/pages/Technical Documentation/Payara Micro Documentation/Payara Micro Configuration and Management/Micro Management/Configuring An Instance.adoc
+++ b/docs/modules/ROOT/pages/Technical Documentation/Payara Micro Documentation/Payara Micro Configuration and Management/Micro Management/Configuring An Instance.adoc
@@ -313,6 +313,7 @@ Payara Micro supports the following system properties:
 |*`payaramicro.maxHttpThreads`*|`--maxHttpThreads`
 |*`payaramicro.minHttpThreads`*|`--minHttpThreads`
 |*`payaramicro.noCluster`*|`--noCluster`
+|*`payaramicro.noHazelcast`*|`--noHazelcast`
 |*`payaramicro.disablePhoneHome`*|`--disablePhoneHome`
 |*`payaramicro.enableRequestTracing`*|`--enableRequestTracing`
 |*`payaramicro.requestTracingThresholdUnit`*|`--requesttracingthresholdunit`

--- a/enterprise/docs/modules/ROOT/pages/Release Notes/Release Notes 5.44.0.adoc
+++ b/enterprise/docs/modules/ROOT/pages/Release Notes/Release Notes 5.44.0.adoc
@@ -6,6 +6,10 @@
 * Java EE 8 Applications
 * MicroProfile 4.1
 
+== Breaking Changes
+=== Disable Hazelcast and Clustering on Payara Micro Changes
+WARNING: Previously the `--noCluster` option was used to disable both Hazelcast and clustering on a Payara Micro instance. In Payara Micro Enterprise Edition 5.44.0 the `--noCluster` option will have Hazelcast enabled, allowing for the use of Hazelcast dependant features such as JCache, while still disabling clustering. To disable both clustering and Hazelcast on Payara Micro Enterprise Edition 5.44.0 you should now use the `--noHazelcast` option.
+
 == Improvement
 
 * [FISH-372] Provide option to disable clustering functionality of Hazelcast on Payara Micro

--- a/enterprise/docs/modules/ROOT/pages/Technical Documentation/Payara Micro Documentation/Payara Micro Docker Image.adoc
+++ b/enterprise/docs/modules/ROOT/pages/Technical Documentation/Payara Micro Documentation/Payara Micro Docker Image.adoc
@@ -172,16 +172,29 @@ CMD ["--deploymentDir", "/opt/payara/deployments", "--contextroot", "my"]
 [[disabling-data-grid]]
 === Disable the Data Grid
 
-Payara Micro will start in "clustering" mode by booting up the xref:Technical Documentation/Payara Micro Documentation/Payara Micro Configuration and Management/Micro Management/Clustering.adoc[Data Grid], allowing other instances reachable in the network to join the grid automatically. 
+Payara Micro will start in "clustering" mode by booting up the xref:/Technical Documentation/Payara Micro Documentation/Payara Micro Configuration and Management/Micro Management/Clustering.adoc[Data Grid], allowing other instances reachable in the network to join the grid automatically.
 
 The Data Grid initialization and maintenance consumes extra resources, so in cases where clustering is not needed, it is recommended to disable the Data Grid completely.
 
-To disable the Data Grid, you can pass the `--noCluster` argument to the entry point of the run command:
+To disable the Data Grid, you can pass the `--noHazelcast` argument to the entry point of the run command:
 
-[source, shell, subs=attributes+]
+[source, shell]
 ----
-docker run -p 8080:8080 \
- -v ~/payara-micro/applications:/opt/payara/deployments nexus.payara.fish:5000/payara/micro:{page-version} --noCluster
+docker run -p 8080:8080 -v ~/payara-micro/applications:/opt/payara/deployments payara/micro --noHazelcast
+----
+
+[[disabling-clustering]]
+=== Disable Clustering
+
+By default, Payara Micro will start with hazelcast enabled, allowing other instances reachable in the network to join the datagrid automatically and cluster.
+
+Disabling Hazelcast with the <<disabling-data-grid, --noHazelcast>> option will also disable all features that depend on Hazelcast, including JCache. The `--noCluster` option allows you to keep Hazelcast and therefore all features depending on Hazelcast, but disable clustering. This will significantly improve performance and is the recommended option if you require Hazelcast dependant features, but do not intend to use clustering.
+
+To disable clustering, you can pass the `--noCluster` argument to the entry point of the run command:
+
+[source, shell]
+----
+docker run -p 8080:8080 -v ~/payara-micro/applications:/opt/payara/deployments payara/micro --noCluster
 ----
 
 [[using-environment-variables]]


### PR DESCRIPTION
Documents the `--noHazelcast` and `--noCluster` options for Payara Micro & the docker image. Adds a breaking change notice (Reviewed by Dominika)