### PR TITLE
FISH-6574 (P6) Docker Images JDK 11

### DIFF
--- a/community/docs/modules/ROOT/pages/Technical Documentation/Payara Micro Documentation/Payara Micro Docker Image.adoc
+++ b/community/docs/modules/ROOT/pages/Technical Documentation/Payara Micro Documentation/Payara Micro Docker Image.adoc
@@ -28,20 +28,12 @@ docker run -p 8080:8080 payara/micro:{page-version}
 [[jdk-version]]
 == Specifying the JDK Version
 
-There are 3 different, alternative versions of the JDK images:
+There are 2 different, alternative versions of the JDK images:
 
-* The default version which is based on **JDK8**, uses no suffix.
-* The **JDK 11** version, which uses the `-jdk11` suffix.
+* The default version which is based on **JDK11**, uses no suffix.
 * The **JDK 17** version, which uses the `-jdk17` suffix.
 
-To switch from the default JDK 8 based image to the JDK 11 compatible one, just add the corresponding suffix to the tag's name like this:
-
-[source, shell, subs=attributes+]
-----
-docker run -p 8080:8080 payara/micro:{page-version}-jdk11
-----
-
-To switch from the default JDK 8 based image to the JDK 17 compatible one, just add the corresponding suffix to the tag's name like this:
+To switch from the default JDK 11 based image to the JDK 17 compatible one, just add the corresponding suffix to the tag's name like this:
 
 [source, shell, subs=attributes+]
 ----
@@ -83,17 +75,14 @@ The following command will start a new Payara Micro instance container and deplo
 
 [source, shell]
 ----
-docker run -p 8080:8080 \
- -v ~/payara-micro/applications:/opt/payara/deployments payara/micro
+docker run -p 8080:8080 -v ~/payara-micro/applications:/opt/payara/deployments payara/micro
 ----
 
 To only deploy a specific artefact within the directory, simply pass the `--deploy` argument to the container's run command and specify which application to deploy:
 
 [source, shell]
 ----
-docker run -p 8080:8080 \
- -v ~/payara-micro/applications:/opt/payara/deployments \
- payara/micro --deploy /opt/payara/deployments/myapplication.war
+docker run -p 8080:8080 -v ~/payara-micro/applications:/opt/payara/deployments payara/micro --deploy /opt/payara/deployments/myapplication.war
 ----
 
 NOTE: Make sure to prefix the artefact names with the absolute path to the local deployment directory.
@@ -120,9 +109,7 @@ Here's an example of how to deploy a sample application located in a local Maven
 
 [source, shell]
 ----
-docker run -p 8080:8080 payara/micro \
- --deployFromGAV "fish.payara.examples:my-application:1.0-SNAPSHOT" \
- --additionalRepository https://172.17.0.10/content/repositories/snapshots
+docker run -p 8080:8080 payara/micro --deployFromGAV "fish.payara.examples:my-application:1.0-SNAPSHOT"  --additionalRepository https://172.17.0.10/content/repositories/snapshots
 ----
 
 Notice that the example also uses the `--additionalRepository` argument to specify the URL of the repository where the artefact lives since by default, Payara Micro will only look for artefacts in the Maven Central repository.
@@ -142,20 +129,13 @@ Here are some basic examples:
 [source, shell]
 .One application deployed, uses the `myRoot` context root
 ----
-docker run -p 8080:8080 \
- -v ~/payara-micro/applications:/opt/payara/deployments payara/micro  \
---deploymentDir /opt/payara/deployments  \
- --contextroot myRoot
+docker run -p 8080:8080 -v ~/payara-micro/applications:/opt/payara/deployments payara/micro --deploymentDir /opt/payara/deployments --contextroot myRoot
 ----
 
 [source, shell]
 .First application in the directory uses the `/` context root
 ----
-docker run -p 8080:8080 \
- -v ~/payara-micro/applications:/opt/payara/deployments \
- payara/micro \
- --deploy /opt/payara/deployments/myapplication.war \
- --contextroot ROOT
+docker run -p 8080:8080 -v ~/payara-micro/applications:/opt/payara/deployments payara/micro --deploy /opt/payara/deployments/myapplication.war --contextroot ROOT
 ----
 
 You can also prepare a custom Docker image that overrides the default `CMD` instruction to specify the context root like this:

--- a/community/docs/modules/ROOT/pages/Technical Documentation/Payara Server Documentation/Payara Server Docker Image.adoc
+++ b/community/docs/modules/ROOT/pages/Technical Documentation/Payara Server Documentation/Payara Server Docker Image.adoc
@@ -33,7 +33,7 @@ Besides the Full Profile version, the Payara Server Web Profile distribution is 
 [[jdk-version]]
 == Specifying the JDK Version
 
-There are 3 different, alternative versions of the JDK images:
+There are 2 different, alternative versions of the JDK images:
 
 * The default version which is based on **JDK11**, uses no suffix.
 * The **JDK 17** version, which uses the `-jdk17` suffix.

--- a/enterprise/docs/modules/ROOT/pages/Technical Documentation/Payara Micro Documentation/Payara Micro Docker Image.adoc
+++ b/enterprise/docs/modules/ROOT/pages/Technical Documentation/Payara Micro Documentation/Payara Micro Docker Image.adoc
@@ -30,20 +30,12 @@ docker run -p 8080:8080 nexus.payara.fish:5000/payara/micro:{page-version}
 [[jdk-version]]
 == Specifying the JDK Version
 
-There are 3 different, alternative versions of the JDK images:
+There are 2 different, alternative versions of the JDK images:
 
-* The default version which is based on **JDK8**, uses no suffix.
-* The **JDK 11** version, which uses the `-jdk11` suffix.
+* The default version which is based on **JDK11**, uses no suffix.
 * The **JDK 17** version, which uses the `-jdk17` suffix.
 
-To switch from the default JDK 8 based image to the JDK 11 compatible one, just add the corresponding suffix to the tag's name like this:
-
-[source, shell]
-----
-docker run -p 8080:8080 nexus.payara.fish:5000/payara/micro:{page-version}-jdk11
-----
-
-To switch from the default JDK 8 based image to the JDK 17 compatible one, just add the corresponding suffix to the tag's name like this:
+To switch from the default JDK 11 based image to the JDK 17 compatible one, just add the corresponding suffix to the tag's name like this:
 
 [source, shell]
 ----
@@ -85,17 +77,14 @@ The following command will start a new Payara Micro instance container and deplo
 
 [source, shell, subs=attributes+]
 ----
-docker run -p 8080:8080 \
- -v ~/payara-micro/applications:/opt/payara/deployments nexus.payara.fish:5000/payara/micro:{page-version}
+docker run -p 8080:8080 -v ~/payara-micro/applications:/opt/payara/deployments nexus.payara.fish:5000/payara/micro:{page-version}
 ----
 
 To only deploy a specific artefact within the directory, simply pass the `--deploy` argument to the container's run command and specify which application to deploy:
 
 [source, shell, subs=attributes+]
 ----
-docker run -p 8080:8080 \
- -v ~/payara-micro/applications:/opt/payara/deployments \
- nexus.payara.fish:5000/payara/micro:{page-version} --deploy /opt/payara/deployments/myapplication.war
+docker run -p 8080:8080 -v ~/payara-micro/applications:/opt/payara/deployments nexus.payara.fish:5000/payara/micro:{page-version} --deploy /opt/payara/deployments/myapplication.war
 ----
 
 NOTE: Make sure to prefix the artefact names with the absolute path to the local deployment directory.
@@ -122,9 +111,7 @@ Here's an example of how to deploy a sample application located in a local Maven
 
 [source, shell, subs=attributes+]
 ----
-docker run -p 8080:8080 nexus.payara.fish:5000/payara/micro:{page-version} \
- --deployFromGAV "fish.payara.examples:my-application:1.0-SNAPSHOT" \
- --additionalRepository https://172.17.0.10/content/repositories/snapshots
+docker run -p 8080:8080 nexus.payara.fish:5000/payara/micro:{page-version} --deployFromGAV "fish.payara.examples:my-application:1.0-SNAPSHOT" --additionalRepository https://172.17.0.10/content/repositories/snapshots
 ----
 
 Notice that the example also uses the `--additionalRepository` argument to specify the URL of the repository where the artefact lives since by default, Payara Micro will only look for artefacts in the Maven Central repository.
@@ -144,20 +131,14 @@ Here are some basic examples:
 [source, shell, subs=attributes+]
 .One application deployed, uses the `myRoot` context root
 ----
-docker run -p 8080:8080 \
- -v ~/payara-micro/applications:/opt/payara/deployments nexus.payara.fish:5000/payara/micro:{page-version}  \
---deploymentDir /opt/payara/deployments  \
- --contextroot myRoot
+docker run -p 8080:8080 -v ~/payara-micro/applications:/opt/payara/deployments nexus.payara.fish:5000/payara/micro:{page-version} --deploymentDir /opt/payara/deployments --contextroot myRoot
 ----
 
 [source, shell, subs=attributes+]
 .First application in the directory uses the `/` context root
 ----
 docker run -p 8080:8080 \
- -v ~/payara-micro/applications:/opt/payara/deployments \
- nexus.payara.fish:5000/payara/micro:{page-version} \
- --deploy /opt/payara/deployments/myapplication.war \
- --contextroot ROOT
+ -v ~/payara-micro/applications:/opt/payara/deployments nexus.payara.fish:5000/payara/micro:{page-version} --deploy /opt/payara/deployments/myapplication.war --contextroot ROOT
 ----
 
 You can also prepare a custom Docker image that overrides the default `CMD` instruction to specify the context root like this:

--- a/enterprise/docs/modules/ROOT/pages/Technical Documentation/Payara Server Documentation/Payara Server Docker Image.adoc
+++ b/enterprise/docs/modules/ROOT/pages/Technical Documentation/Payara Server Documentation/Payara Server Docker Image.adoc
@@ -35,7 +35,7 @@ Besides the Full Profile version, the Payara Server Web Profile distribution is 
 [[jdk-version]]
 == Specifying the JDK Version
 
-There are 3 different, alternative versions of the JDK images:
+There are 2 different, alternative versions of the JDK images:
 
 * The default version which is based on **JDK11**, uses no suffix.
 * The **JDK 17** version, which uses the `-jdk17` suffix.


### PR DESCRIPTION
Docker images now use JDK 11 as the base version, update the documentation to reflect this