### PR TITLE
FISH-5646: new version of Client Certificate validator doesn't have the Injection possibilities

### DIFF
--- a/docs/modules/ROOT/pages/Technical Documentation/Payara Server Documentation/Server Configuration And Management/Security Configuration/Client Certificates/Custom Validators.adoc
+++ b/docs/modules/ROOT/pages/Technical Documentation/Payara Server Documentation/Server Configuration And Management/Security Configuration/Client Certificates/Custom Validators.adoc
@@ -49,8 +49,6 @@ This class is loaded through the Java ServiceLoader mechanism. Make sure you hav
 com.company.certificate.MyCertificateValidator
 ----
 
-NOTE: You can @Inject CDI and EJB beans in your validator implementation, however since the validator itself is not a Jakarta EE bean, `@PostConstruct` and `@PreDestroy`-annotated methods will not be called on the validator instance.
-
 [[client-certificate-expiration-validator]]
 == Certificate Expiration Validation
 


### PR DESCRIPTION
FISH-5646: new version of Client Certificate validator doesn't have the Injection possibilities