### PR TITLE
FISH-1175 Typo in Clustered Annotation

### DIFF
--- a/docs/modules/ROOT/pages/Technical Documentation/Public API/Clustered Singleton.adoc
+++ b/docs/modules/ROOT/pages/Technical Documentation/Public API/Clustered Singleton.adoc
@@ -20,8 +20,8 @@ IMPORTANT: If the purpose of a clustered singleton bean is to only define a pers
 [[initialization]]
 == `@Clustered` and `@Startup` / `@Initialized` `@ApplicationScoped`
 
-Care must be taken in this scenario. By default, the `@PostConstruct` lifecycle method is called for every instance in the cluster for these beans. This behavior needs to be disabled by using `@Clustered(callPostConstructOnAttach = false)` and possibly `callPreDestroyOnDetach = false` as well, so only the `@PostConstcut` method will be called only once per cluster.
-`@Observed` `@Initialzed` methods are called for every instance in the cluster. The only valid method for cluster-wide initialization is to use the `@PostConstruct` lifecycle method configured as described above.
+Care must be taken in this scenario. By default, the `@PostConstruct` lifecycle method is called for every instance in the cluster for these beans. This behavior needs to be disabled by using `@Clustered(callPostConstructOnAttach = false)` and possibly `callPreDestroyOnDetach = false` as well, so only the `@PostConstruct` method will be called only once per cluster.
+`@Observed` `@Initialized` methods are called for every instance in the cluster. The only valid method for cluster-wide initialization is to use the `@PostConstruct` lifecycle method configured as described above.
 
 [[cdinotes]]
 == CDI Considerations and Notes

--- a/docs/modules/ROOT/pages/Technical Documentation/Public API/Clustered Singleton.adoc
+++ b/docs/modules/ROOT/pages/Technical Documentation/Public API/Clustered Singleton.adoc
@@ -20,7 +20,7 @@ IMPORTANT: If the purpose of a clustered singleton bean is to only define a pers
 [[initialization]]
 == `@Clustered` and `@Startup` / `@Initialized` `@ApplicationScoped`
 
-Care must be taken in this scenario. By default, the `@PostConstruct` lifecycle method is called for every instance in the cluster for these beans. This behavior needs to be disabled by using `@Clustered(callPostConstructOnAttach = false)` and possibly `callPreDestoyOnDetach = false` as well, so only the `@PostConstcut` method will be called only once per cluster.
+Care must be taken in this scenario. By default, the `@PostConstruct` lifecycle method is called for every instance in the cluster for these beans. This behavior needs to be disabled by using `@Clustered(callPostConstructOnAttach = false)` and possibly `callPreDestroyOnDetach = false` as well, so only the `@PostConstcut` method will be called only once per cluster.
 `@Observed` `@Initialzed` methods are called for every instance in the cluster. The only valid method for cluster-wide initialization is to use the `@PostConstruct` lifecycle method configured as described above.
 
 [[cdinotes]]


### PR DESCRIPTION
Documents the fix for the typo in the Clustered annotation: https://github.com/payara/Payara/pull/6024
Also includes another couple of typo fixes.