### PR TITLE
FISH-6715 (P6) CVE-2022-42920 Fix List Documentation

### DIFF
--- a/community/docs/modules/ROOT/pages/Security/Security Fix List.adoc
+++ b/community/docs/modules/ROOT/pages/Security/Security Fix List.adoc
@@ -7,6 +7,8 @@ The following is a list of tracked _**C**ommon **V**ulnerabilities and **E**xpos
 |=======================================================================
 |ID |CVSS v3.0 Base Score |Status |Summary |Release |Pull Requests |Observations
 
+|https://nvd.nist.gov/vuln/detail/CVE-2022-42920[CVE-2022-42920] | 9.8 | FIXED | Apache Commons BCEL has a number of APIs that would normally only allow changing specific class characteristics. However, due to an out-of-bounds writing issue, these APIs can be used to produce arbitrary bytecode. This could be abused in applications that pass attacker-controllable data to those APIs, giving the attacker more control over the resulting bytecode than otherwise expected. | 6.2022.2 | https://github.com/payara/Payara/pull/6056[#6056] | Fixed by Apache BCEL to 6.6.1
+
 |https://nvd.nist.gov/vuln/detail/CVE-2020-36518[CVE-2020-36518] | 7.5 | FIXED | jackson-databind allows a Java StackOverflow exception and denial of service via a large depth of nested objects. | 5.2022.2 | https://github.com/payara/Payara/pull/5695[#5695] | Fixed by upgrading jackson-databind to 2.12.6.1
 
 |https://nvd.nist.gov/vuln/detail/CVE-2018-25032[CVE-2018-25032] | 7.5 | FIXED | ZLib allows memory corruption when deflating (i.e. when compressing) if the input has many distant matches. | 5.2022.2 | https://github.com/payara/Payara/pull/5638[#5638] | Fixed by upgrading to Azul JDK version using ZLib 1.2.12 in Payara Docker Images.

--- a/enterprise/docs/modules/ROOT/pages/Security/Security Fix List.adoc
+++ b/enterprise/docs/modules/ROOT/pages/Security/Security Fix List.adoc
@@ -7,6 +7,8 @@ The following is a list of tracked _**C**ommon **V**ulnerabilities and **E**xpos
 |=======================================================================
 |ID |CVSS v3.0 Base Score |Status |Summary |Release |Observations
 
+|https://nvd.nist.gov/vuln/detail/CVE-2022-42920[CVE-2022-42920] | 9.8 | FIXED | Apache Commons BCEL has a number of APIs that would normally only allow changing specific class characteristics. However, due to an out-of-bounds writing issue, these APIs can be used to produce arbitrary bytecode. This could be abused in applications that pass attacker-controllable data to those APIs, giving the attacker more control over the resulting bytecode than otherwise expected. | 6.2022.2 | Fixed by Apache BCEL to 6.6.1
+
 |https://nvd.nist.gov/vuln/detail/CVE-2020-36518[CVE-2020-36518] | 7.5 | FIXED | jackson-databind allows a Java StackOverflow exception and denial of service via a large depth of nested objects. | 5.38.0 | Fixed by upgrading jackson-databind to 2.12.6.1
 
 |https://nvd.nist.gov/vuln/detail/CVE-2018-25032[CVE-2018-25032] | 7.5 | FIXED | ZLib allows memory corruption when deflating (i.e. when compressing) if the input has many distant matches. | 5.38.0 | Fixed by upgrading to Azul JDK version using ZLib 1.2.12 in Payara Docker Images.


### PR DESCRIPTION
Documents CVE-2022-42920 in the Security Fix List. 