### PR TITLE
FISH-6644 (Ent-Docs) Security Fix List

### DIFF
--- a/enterprise/docs/modules/ROOT/pages/Security/Security Fix List.adoc
+++ b/enterprise/docs/modules/ROOT/pages/Security/Security Fix List.adoc
@@ -7,7 +7,11 @@ The following is a list of tracked _**C**ommon **V**ulnerabilities and **E**xpos
 |=======================================================================
 |ID |CVSS v3.0 Base Score |Status |Summary |Release |Observations
 
-|https://nvd.nist.gov/vuln/detail/CVE-2022-42920[CVE-2022-42920] | 9.8 | FIXED | Apache Commons BCEL has a number of APIs that would normally only allow changing specific class characteristics. However, due to an out-of-bounds writing issue, these APIs can be used to produce arbitrary bytecode. This could be abused in applications that pass attacker-controllable data to those APIs, giving the attacker more control over the resulting bytecode than otherwise expected.  | 5.46.0 | Fixed by upgrading Apache BCEL to 6.6.1
+|https://nvd.nist.gov/vuln/detail/CVE-2022-2068[CVE-2022-2068] | 9.8 | FIXED | In addition to the c_rehash shell command injection identified in CVE-2022-1292, further circumstances where the c_rehash script does not properly sanitise shell metacharacters to prevent command injection were found by code review. | 5.47.0 | Fixed by removing OpenSSL from Payara Docker Images
+
+|https://nvd.nist.gov/vuln/detail/CVE-2022-1292[CVE-2022-1292] | 9.8 | FIXED | The c_rehash script does not properly sanitise shell metacharacters to prevent command injection. This script is distributed by some operating systems in a manner where it is automatically executed. On such operating systems, an attacker could execute arbitrary commands with the privileges of the script. Use of the c_rehash script is considered obsolete and should be replaced by the OpenSSL rehash command line tool. | 5.47.0 | Fixed by removing OpenSSL from Payara Docker Images
+
+|https://nvd.nist.gov/vuln/detail/CVE-2022-42920[CVE-2022-42920] | 9.8 | FIXED | Apache Commons BCEL has a number of APIs that would normally only allow changing specific class characteristics. However, due to an out-of-bounds writing issue, these APIs can be used to produce arbitrary bytecode. This could be abused in applications that pass attacker-controllable data to those APIs, giving the attacker more control over the resulting bytecode than otherwise expected. | 5.46.0 | Fixed by upgrading Apache BCEL to 6.6.1
 
 |https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-31684[CVE-2021-31684] | N/A | FIXED | A vulnerability was discovered in the indexOf function of JSONParserByteArray in JSON Smart versions 1.3 and 2.4 which causes a denial of service (DOS) via a crafted web request. | 5.44.0 | Fixed by upgrading nimbus-jose-jwt to 9.25
 


### PR DESCRIPTION
Adds security fix list information for CVE-2022-1292 CVE-2022-2068 fixed in https://github.com/payara/Payara-Enterprise/pull/731