### PR TITLE
FISH-6644 (P6-Docs) Security Fix List

### DIFF
--- a/community/docs/modules/ROOT/pages/Security/Security Fix List.adoc
+++ b/community/docs/modules/ROOT/pages/Security/Security Fix List.adoc
@@ -7,6 +7,10 @@ The following is a list of tracked _**C**ommon **V**ulnerabilities and **E**xpos
 |=======================================================================
 |ID |CVSS v3.0 Base Score |Status |Summary |Release |Pull Requests |Observations
 
+|https://nvd.nist.gov/vuln/detail/CVE-2022-2068[CVE-2022-2068] | 9.8 | FIXED | In addition to the c_rehash shell command injection identified in CVE-2022-1292, further circumstances where the c_rehash script does not properly sanitise shell metacharacters to prevent command injection were found by code review. | 6.2023.1 | https://github.com/payara/Payara/pull/6104[#6104] | Fixed by removing OpenSSL from Payara Docker Images
+
+|https://nvd.nist.gov/vuln/detail/CVE-2022-1292[CVE-2022-1292] | 9.8 | FIXED | The c_rehash script does not properly sanitise shell metacharacters to prevent command injection. This script is distributed by some operating systems in a manner where it is automatically executed. On such operating systems, an attacker could execute arbitrary commands with the privileges of the script. Use of the c_rehash script is considered obsolete and should be replaced by the OpenSSL rehash command line tool. | 6.2023.1 | https://github.com/payara/Payara/pull/6104[#6104] | Fixed by removing OpenSSL from Payara Docker Images
+
 |https://nvd.nist.gov/vuln/detail/CVE-2022-42920[CVE-2022-42920] | 9.8 | FIXED | Apache Commons BCEL has a number of APIs that would normally only allow changing specific class characteristics. However, due to an out-of-bounds writing issue, these APIs can be used to produce arbitrary bytecode. This could be abused in applications that pass attacker-controllable data to those APIs, giving the attacker more control over the resulting bytecode than otherwise expected. | 6.2022.2 | https://github.com/payara/Payara/pull/6056[#6056] | Fixed by Apache BCEL to 6.6.1
 
 |https://nvd.nist.gov/vuln/detail/CVE-2020-36518[CVE-2020-36518] | 7.5 | FIXED | jackson-databind allows a Java StackOverflow exception and denial of service via a large depth of nested objects. | 5.2022.2 | https://github.com/payara/Payara/pull/5695[#5695] | Fixed by upgrading jackson-databind to 2.12.6.1


### PR DESCRIPTION
Adds security fix list information for CVE-2022-1292 CVE-2022-2068 fixed in https://github.com/payara/Payara/pull/6104