### PR TITLE
Edited MP OpenAPI extension properties

### DIFF
--- a/community/docs/modules/ROOT/pages/Release Notes/Release Notes 5.2022.4.adoc
+++ b/community/docs/modules/ROOT/pages/Release Notes/Release Notes 5.2022.4.adoc
@@ -7,6 +7,7 @@
 * MicroProfile 4.1
 
 == Security Vulnerability
+
 IMPORTANT: We have been made aware of a 0-day vulnerability. This vulnerability exploit opens up to attackers a way to explore the contents of the WEB-INF and META-INF folders if an application is deployed to the root context. This vulnerability is similar to another 0-day vulnerability (CVE-2022-37422) we recently had. We would like to thank Michael Baer, Luc Créti and Jean-Michel Lenotte, all working for Atos, for alerting us to this vulnerability. You must upgrade to this latest version of Payara 5 Community to avoid the security issue.
 
 == Improvements

--- a/community/docs/modules/ROOT/pages/Release Notes/Release Notes 5.2022.5.adoc
+++ b/community/docs/modules/ROOT/pages/Release Notes/Release Notes 5.2022.5.adoc
@@ -18,8 +18,9 @@ Payara 5.2022.5 is the final release of Payara 5 Community. Payara 5 Community w
 == Security Fixes
 
 * [https://github.com/payara/Payara/pull/6056[FISH-6715]] Upgrade Apache BCEL to 6.6.1
+* [https://github.com/payara/Payara/pull/6080[FISH-6775]] Authorization Constraints Ignored When Using Path Traversal Penetration Using Default Virtual Module. 
 
-* [https://github.com/payara/Payara/pull/6080[FISH-6775]] Authorization Constraints Ignored When Using Path Traversal Penetration Using Default Virtual Module
+NOTE: Special thanks to *Luc Créti* and *Jean-Michel Lenotte*, working for Atos, for alerting us to the vulnerability fixed in `FISH-6775`.
 
 == Bug Fixes
 

--- a/community/docs/modules/ROOT/pages/Technical Documentation/MicroProfile/OpenAPI.adoc
+++ b/community/docs/modules/ROOT/pages/Technical Documentation/MicroProfile/OpenAPI.adoc
@@ -38,10 +38,10 @@ MicroProfile OpenAPI specifies several ways of configuring the data in the produ
 [[sources-config]]
 === Config Properties
 
-The OpenAPI can be configured through the xref:Technical Documentation/MicroProfile/Config/Overview.adoc[Config API]. For example, these configuration properties can be put in the `microprofile-config.properties`.
+The OpenAPI document generation process can be configured through the xref:Technical Documentation/MicroProfile/Config/Overview.adoc[Config API]. The following are the standard configuration properties as presented by the specification:
 
 |===
-| Config key | Value description
+| Property key | Description
 
 | `mp.openapi.model.reader` | Configuration property to specify the fully qualified name of the <<sources-model-reader, OASModelReader>> implementation.
 | `mp.openapi.filter` | Configuration property to specify the fully qualified name of the <<sources-filter, OASFilter>> implementation.
@@ -54,7 +54,6 @@ The OpenAPI can be configured through the xref:Technical Documentation/MicroProf
 `mp.openapi.scan.exclude.packages=com.xyz.PackageC,com.xyz.PackageD`
 | `mp.openapi.scan.exclude.classes`  |  Configuration property to specify the list of classes to exclude from scans. For example,
 `mp.openapi.scan.exclude.classes=com.xyz.MyClassC,com.xyz.MyClassD`
-| `mp.openapi.scan.lib`  |  Configuration property to scan the packaged jar files inside the WAR (WEB-INF\lib). Default value is `false`.
 | `mp.openapi.servers`  |  Configuration property to specify the list of global servers that provide connectivity information. For example,
 `mp.openapi.servers=https://xyz.com/v1,https://abc.com/v1`
 | `mp.openapi.servers.path.`   |  Prefix of the configuration property to specify an alternative list of servers to service all operations in a path. For example,
@@ -78,6 +77,13 @@ mp.openapi.schema.java.util.Date = { \
   "description": "Milliseconds since January 1, 1970, 00:00:00 GMT" \
 }
 ----
+|===
+
+In addition to the standard properties, the following properties have been added as extensions within the Payara Platform:
+
+|===
+| Property key | Description
+| `mp.openapi.scan.lib`  |  Configuration property that allows the server to scan packaged JAR files inside the WAR's library directory (`WEB-INF/lib`). Default value is `false`.
 |===
 
 [[sources-model-reader]]
@@ -368,6 +374,6 @@ Gets the status of the OpenAPI service.
 
 [[security-configuration]]
 === Security Configuration
-By default, the OpenAPI endpoint binds to the root context application which is the `__default-web-module` (also known as *docroot*) system application and the `__default-web-module` application, which is secured under the default realm (`file`) of the server. 
+By default, the OpenAPI endpoint binds to the root context application which is the `__default-web-module` (also known as `docroot`) system application and the `__default-web-module` application, which is secured under the default realm (`file`) of the server. 
 
 If a user application is deployed in the empty context-root, then the security configuration of this application will be shared by the OpenAPI endpoint, so exert extreme caution when making these changes.

--- a/enterprise/docs/modules/ROOT/pages/Release Notes/Release Notes 5.46.0.adoc
+++ b/enterprise/docs/modules/ROOT/pages/Release Notes/Release Notes 5.46.0.adoc
@@ -15,8 +15,9 @@
 == Security Fixes
 
 * [FISH-6715] Upgrade Apache BCEL to 6.6.1
-
 * [FISH-6775] Authorization Constraints Ignored When Using Path Traversal Penetration Using Default Virtual Module
+
+NOTE: Special thanks to *Luc Créti* and *Jean-Michel Lenotte*, working for Atos, for alerting us to the vulnerability fixed in `FISH-6775`.
 
 == Bug Fixes
 

--- a/enterprise/docs/modules/ROOT/pages/Technical Documentation/MicroProfile/OpenAPI.adoc
+++ b/enterprise/docs/modules/ROOT/pages/Technical Documentation/MicroProfile/OpenAPI.adoc
@@ -38,10 +38,11 @@ MicroProfile OpenAPI specifies several ways of configuring the data in the produ
 [[sources-config]]
 === Configuration Properties
 
-The OpenAPI can be configured through the xref:Technical Documentation/MicroProfile/Config/Overview.adoc[Config API]. For example, these configuration properties can be put in the `microprofile-config.properties`.
+The OpenAPI document generation process can be configured through the xref:Technical Documentation/MicroProfile/Config/Overview.adoc[Config API]. The following are the standard configuration properties as presented by the specification:
 
 |===
-| Config key | Value description
+| Property key | Description
+
 | `mp.openapi.model.reader` | Configuration property to specify the fully qualified name of the <<sources-model-reader, OASModelReader>> implementation.
 | `mp.openapi.filter` | Configuration property to specify the fully qualified name of the <<sources-filter, OASFilter>> implementation.
 | `mp.openapi.scan.disable`  |  Configuration property to disable annotation scanning. Default value is `false`.
@@ -53,7 +54,6 @@ The OpenAPI can be configured through the xref:Technical Documentation/MicroProf
 `mp.openapi.scan.exclude.packages=com.xyz.PackageC,com.xyz.PackageD`
 | `mp.openapi.scan.exclude.classes`  |  Configuration property to specify the list of classes to exclude from scans. For example,
 `mp.openapi.scan.exclude.classes=com.xyz.MyClassC,com.xyz.MyClassD`
-| `mp.openapi.scan.lib`  |  Configuration property to scan the packaged jar files inside the WAR (WEB-INF\lib). Default value is `false`.
 | `mp.openapi.servers`  |  Configuration property to specify the list of global servers that provide connectivity information. For example,
 `mp.openapi.servers=https://xyz.com/v1,https://abc.com/v1`
 | `mp.openapi.servers.path.`   |  Prefix of the configuration property to specify an alternative list of servers to service all operations in a path. For example,
@@ -77,6 +77,13 @@ mp.openapi.schema.java.util.Date = { \
   "description": "Milliseconds since January 1, 1970, 00:00:00 GMT" \
 }
 ----
+|===
+
+In addition to the standard properties, the following properties have been added as extensions within the Payara Platform:
+
+|===
+| Property key | Description
+| `mp.openapi.scan.lib`  |  Configuration property that allows the server to scan packaged JAR files inside the WAR's library directory (`WEB-INF/lib`). Default value is `false`.
 |===
 
 [[sources-model-reader]]
@@ -365,7 +372,7 @@ Gets the status of the OpenAPI service.
 
 [[security-configuration]]
 === Security Configuration
-By default, the OpenAPI endpoint binds to the root context application which is the `__default-web-module` (also known as *docroot*) system application and the `__default-web-module` application, which is secured under the default realm (`file`) of the server. 
+By default, the OpenAPI endpoint binds to the root context application which is the `__default-web-module` (also known as `docroot`) system application and the `__default-web-module` application, which is secured under the default realm (`file`) of the server. 
 
 If a user application is deployed in the empty context-root, then the security configuration of this application will be shared by the OpenAPI endpoint, so exert extreme caution when making these changes.
 


### PR DESCRIPTION
Based on the findings of FISH-6927, adapted the documentation of the MP OpenAPI configuration properties to list `mp.openapi.scan.lib` as an extension property.

The following PRs were made to port this one to its contemporary branch releases:

* #174 
* #175
* #176
* #177