### PR TITLE
FISH-6609 Update Cloud Connectors for JakartaEE 10

### DIFF
--- a/community/docs/modules/ROOT/pages/Technical Documentation/Ecosystem/Connector Suites/Cloud Connectors/Overview.adoc
+++ b/community/docs/modules/ROOT/pages/Technical Documentation/Ecosystem/Connector Suites/Cloud Connectors/Overview.adoc
@@ -1,4 +1,4 @@
-
+[[cloud-connectors]]
 = Cloud Connectors
 
 The Payara Cloud Connectors are a collection of JCA adapters for use with various popular cloud messaging providers. These connectors can be deployed to either Payara Server or Payara Micro.
@@ -10,6 +10,7 @@ The following connectors are available:
 * xref:/Technical Documentation/Ecosystem/Connector Suites/Cloud Connectors/MQTT.adoc[MQTT]
 * xref:/Technical Documentation/Ecosystem/Connector Suites/Cloud Connectors/Azure SB.adoc[Azure Service Bus]
 
+[[obtaining-connectors]]
 == Obtaining the connectors
 
 Cloud Connectors can be built from source as follows:
@@ -43,17 +44,19 @@ The connectors can be found in the following locations as JCA RARs:
 * MQTT - ./MQTT/MQTTRAR/target/mqtt-rar-0.8.0.rar
 * Azure Service Bus - ./AzureServiceBus/AzureSBRAR/target/azure-sb-rar-0.8.0.rar
 
-[[Installing-a-connector]]
+[[installing-a-connector]]
 == Installing a connector
 
 Installing Cloud Connectors for Payara Server and Payara Micro both require the Cloud Connector jar to be deployed. However, Payara Server requires some additional configuration to classloading.
 
 A connector (JCA rar) is installed by deploying it in the same way as an application archive (e.g. a .war) is deployed:
 
+[[install-connector-server]]
 === Payara Server
 
 You can configure Payara Server through the Admin Console or through the Asadmin CLI.
 
+[[install-connector-server-admin-console]]
 ==== Using the Admin Console
 
 You can deploy the connector with the admin console;
@@ -66,6 +69,7 @@ image:cloud-connectors/classloading-configuration.png[Classloading Config]
 
 This allows the classes from the cloud connector to be globally available in the server.
 
+[[install-connector-server-asadmin]]
 ==== Using the Asadmin CLI
 
 Deploy the application with the CLI;
@@ -80,6 +84,7 @@ Configure the classloading policy;
 asadmin> set configs.config.server-config.connector-service.class-loading-policy=global
 ----
 
+[[install-connector-micro]]
 === Payara Micro
 
 ----
@@ -92,6 +97,7 @@ The connector is subsequently available to all other applications deployed to Pa
 java -jar payara-micro.jar --autobindhttp --deploy kafka-rar-0.8.0.rar --deploy myapp.war
 ----
 
+[[securing-credentials]]
 == Securing credentials
 
 In the documentation pages for the currently available cloud connectors, much of the configuration shown is done via annotations. This configuration

--- a/docs/modules/ROOT/pages/Technical Documentation/Ecosystem/Connector Suites/Cloud Connectors/Amazon SQS/Overview.adoc
+++ b/docs/modules/ROOT/pages/Technical Documentation/Ecosystem/Connector Suites/Cloud Connectors/Amazon SQS/Overview.adoc
@@ -1,3 +1,4 @@
+[[sqs-connector]]
 = Amazon SQS Cloud Connector
 
 Amazon SQS (Simple Queue Service) is a hosted and highly scalable distributed message queue service.

--- a/docs/modules/ROOT/pages/Technical Documentation/Ecosystem/Connector Suites/Cloud Connectors/Amazon SQS/SSO Integration.adoc
+++ b/docs/modules/ROOT/pages/Technical Documentation/Ecosystem/Connector Suites/Cloud Connectors/Amazon SQS/SSO Integration.adoc
@@ -1,4 +1,5 @@
 :ordinal: 2
+[[aws-sso-integration]]
 = Amazon Web Services SSO Integration
 
 If you are using version 2 of the Amazon Web Services Java SDK, then it is possible to configure the SQS connector use Amazon SSO authentication instead of a `secretKey` and `keyID` set of credentials.
@@ -41,7 +42,7 @@ image::cloud-connectors/sqs-connector/amazon-sqs-settings.png[Amazon SQS Setting
 [[download-install-amazon-sqs-connector-v2]]
 == Download and install Amazon SQS Connector version 2 from Payara
 
-To download and install Amazon SQS Connector V2, please check xref:/Technical Documentation/Ecosystem/Connector Suites/Cloud Connectors/Amazon SQS Versioning.adoc#how-to-use[How to use] of the Amazon SQS Versioning.
+To download and install Amazon SQS Connector V2, please check xref:Technical Documentation/Ecosystem/Connector Suites/Cloud Connectors/Amazon SQS/Versioning.adoc#install-connector-server[How to use] of the Amazon SQS Versioning.
 
 [[install-amazon-cli-local-environment]]
 == Install Amazon CLI Locally

--- a/docs/modules/ROOT/pages/Technical Documentation/Ecosystem/Connector Suites/Cloud Connectors/Amazon SQS/Versioning.adoc
+++ b/docs/modules/ROOT/pages/Technical Documentation/Ecosystem/Connector Suites/Cloud Connectors/Amazon SQS/Versioning.adoc
@@ -3,8 +3,14 @@
 
 The SQS connector's behavior and features are affected by the exact version of the Amazon Web Services Java SDK version being planned to use. For each version, there are separate versions of the connector's JCA adapter and its API.
 
+The tags below are for the https://github.com/payara/Cloud-Connectors[Cloud Connectors repository]. You should use the one corresponding to the SQS and Jakarta version you require.
+
+https://github.com/payara/Cloud-Connectors/releases/tag/0.8.0[0.8.0]:: Amazon SQS Version 1 using JakartaEE 8 and the `javax` namespace
+https://github.com/payara/Cloud-Connectors/releases/tag/AmazonSQS-1.0.0[AmazonSQS-1.0.0]:: Amazon SQS Version 2 using JakartaEE 8 and the `javax` namespace
+https://github.com/payara/Cloud-Connectors/releases/tag/AmazonSQS-2.0.0[AmazonSQS-2.0.0]:: Amazon SQS Version 2 using JakartaEE 10 and the `jakarta` namespace
+
 [[amazon-sqs-connector-version-1]]
-== Amazon SQS Connector version 1
+== Amazon SQS Connector Version 1
 
 This is the first version of the connector that is based on https://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/welcome.html[Amazon Web Services Java SDK v1].
 
@@ -36,23 +42,21 @@ Additionally, to use the connector API add the following Maven dependencies to y
 
 NOTE: These dependencies have a provided `scope` since the types within this dependency are globally available to every application deployed to Payara Micro after the `amazon-sqs-rar-0.8.0.rar` has been deployed.
 
-WARNING: It can be confusing, but disregard the version of the artifact, as it constitutes a sequential development of the "first version" of the connector's artifact.
-
 [[amazon-sqs-connector-version-2]]
-== Amazon SQS Connector version 2
+== Amazon SQS Connector Version 2
 
 This is the second version of the connector that is based on https://docs.aws.amazon.com/sdk-for-java/latest/developer-guide/home.html[Amazon Web Services SDK v2].
 
+IMPORTANT: If you have selected to use SQS Connector 2.0.0, replace all occurunces of `1.0.0` with `2.0.0` for the following example.
+
 [[v2-usage]]
 === Usage
-
-To get this version's JCA adapter, checkout the following https://github.com/payara/Cloud-Connectors/releases/tag/sqs-connector-v2-1.0.0[Cloud Connectors V2 tag] tag of the Cloud Connectors official repository and then build the project to install the artifacts:
 
 [source, shell]
 ----
 git clone git@github.com:payara/Cloud-Connectors.git
 cd Cloud-Connectors/
-git checkout tags/sqs-connector-v2-1.0.0 -b sqs-connector-v2-1.0.0
+git checkout tags/AmazonSQS-1.0.0
 mvn clean install
 ----
 

--- a/docs/modules/ROOT/pages/Technical Documentation/Ecosystem/Connector Suites/Cloud Connectors/Apache Kafka.adoc
+++ b/docs/modules/ROOT/pages/Technical Documentation/Ecosystem/Connector Suites/Cloud Connectors/Apache Kafka.adoc
@@ -1,3 +1,4 @@
+[[kafka-connector]]
 = Apache Kafka Cloud Connector
 
 Apache Kafka is an open-source stream processing platform. It is based on a massively scalable publish/subscribe message queue architected as a distributed transaction log.
@@ -26,6 +27,7 @@ In order to make use of this connector in an application, the following Maven de
 
 Note that this dependency has scope `provided` since the types within this dependency are globally available to every application deployed to Payara Micro after the `kafka-rar-0.8.0.rar` was deployed.
 
+[[sending-messages]]
 == Sending messages
 Sending messages to Apache Kafka can be done via the JCA and a Kafka specific API. In order to start using this API to send messages, a resource has to be defined via the JCA API; a connection factory.
 
@@ -64,6 +66,7 @@ public class SendKafkaMessage {
 }
 ----
 
+[[receiving-messages]]
 == Receiving messages
 Messages can be received from Apache Kafka by creating an MDB (Message Driven Bean) that implements the `fish.payara.cloud.connectors.kafka.api.KafkaListener` marker interface and has one or more methods annotated with `@OnRecord` and the method signature `void method(ConsumerRecord record)`, or `@OnRecords` and the method signature `void method(ConsumerRecords records)`
 

--- a/docs/modules/ROOT/pages/Technical Documentation/Ecosystem/Connector Suites/Cloud Connectors/Apache Kafka.adoc
+++ b/docs/modules/ROOT/pages/Technical Documentation/Ecosystem/Connector Suites/Cloud Connectors/Apache Kafka.adoc
@@ -3,6 +3,18 @@
 
 Apache Kafka is an open-source stream processing platform. It is based on a massively scalable publish/subscribe message queue architected as a distributed transaction log.
 
+[[versioning]]
+== Versioning
+The tags below are for the https://github.com/payara/Cloud-Connectors[Cloud Connectors repository]. You should use the one corresponding to the Jakarta version you require.
+
+https://github.com/payara/Cloud-Connectors/releases/tag/0.8.0[0.8.0]:: Kafka Connector using JakartaEE 8 and the `javax` namespace
+https://github.com/payara/Cloud-Connectors/releases/tag/Kafka-1.0.0[Kafka-1.0.0]:: Kafka Connector using JakartaEE 10 and the `jakarta` namespace
+
+[[usage]]
+== Usage
+
+IMPORTANT: If you have selected to use Kafka Connector 1.0.0, replace all occurunces of `0.8.0` with `1.0.0` for the following example.
+
 In order to connect to Apache Kafka, the `kafka-rar-0.8.0.rar` has to be deployed as shown in the xref:Technical Documentation/Ecosystem/Connector Suites/Cloud Connectors/Overview.adoc#installing-a-connector[Installing a connector section] of the Cloud Connectors overview.
 
 Once deployed, something like the following should be printed to the startup log of Payara Micro:

--- a/docs/modules/ROOT/pages/Technical Documentation/Ecosystem/Connector Suites/Cloud Connectors/Apache Kafka.adoc
+++ b/docs/modules/ROOT/pages/Technical Documentation/Ecosystem/Connector Suites/Cloud Connectors/Apache Kafka.adoc
@@ -3,7 +3,7 @@
 
 Apache Kafka is an open-source stream processing platform. It is based on a massively scalable publish/subscribe message queue architected as a distributed transaction log.
 
-In order to connect to Apache Kafka, the `kafka-rar-0.8.0.rar` has to be deployed as shown in the xref:/Technical Documentation/Ecosystem/Connector Suites/Cloud Connectors/Overview.adoc#Installing-a-connector[Installing a connector section] of the Cloud Connectors overview.
+In order to connect to Apache Kafka, the `kafka-rar-0.8.0.rar` has to be deployed as shown in the xref:Technical Documentation/Ecosystem/Connector Suites/Cloud Connectors/Overview.adoc#installing-a-connector[Installing a connector section] of the Cloud Connectors overview.
 
 Once deployed, something like the following should be printed to the startup log of Payara Micro:
 

--- a/docs/modules/ROOT/pages/Technical Documentation/Ecosystem/Connector Suites/Cloud Connectors/Azure SB.adoc
+++ b/docs/modules/ROOT/pages/Technical Documentation/Ecosystem/Connector Suites/Cloud Connectors/Azure SB.adoc
@@ -5,8 +5,7 @@ The Microsoft Azure Service Bus allows code that runs both outside and inside
 Azure to communicate with Azure.
 
 In order to connect to Azure, the `azure-sb-rar-0.8.0.rar` has to
-be deployed as shown in the xref:/Technical Documentation/Ecosystem/Connector Suites/Cloud Connectors/Overview.adoc#Installing-a-connector[
-Installing a connector section] of the Cloud Connectors overview.
+be deployed as shown in the xref:Technical Documentation/Ecosystem/Connector Suites/Cloud Connectors/Overview.adoc#installing-a-connector[Installing a connector section] of the Cloud Connectors overview.
 
 In order to make use of this connector in an application, the following maven dependency is needed:
 
@@ -21,24 +20,16 @@ In order to make use of this connector in an application, the following maven de
 </dependency>
 ----
 
-Note that this dependency have scope provided since the types within this
-dependency are globally available to every application deployed to Payara Micro
-after the `azure-sb-rar-0.8.0.rar` was deployed.
+Note that this dependency have scope provided since the types within this dependency are globally available to every application deployed to Payara Micro after the `azure-sb-rar-0.8.0.rar` was deployed.
 
 [[sending-messages]]
 == Sending messages
 
-Sending messages to Azure can be done via the JCA and an Azure specific API. In
-order to start using this API to send messages, a resource has to be defined via
-the JCA API; a connection factory.
+Sending messages to Azure can be done via the JCA and an Azure specific API. In order to start using this API to send messages, a resource has to be defined via the JCA API; a connection factory.
 
-The connection factory has to be given a name, which can be any name that is
-valid for JNDI. The `java:app` namespace is typically recommended to be used.
-The type of the connection factory to be used for the Azure Service Bus is 
-`fish.payara.cloud.connectors.azuresb.api.AzureSBConnectionFactory`, and we have
-to specify the resource adapter name which is here `AzureSBRAR-0.1.0-SNAPSHOT`.
+The connection factory has to be given a name, which can be any name that is valid for JNDI. The `java:app` namespace is typically recommended to be used. The type of the connection factory to be used for the Azure Service Bus is  `fish.payara.cloud.connectors.azuresb.api.AzureSBConnectionFactory`, and we have to specify the resource adapter name which is here `AzureSBRAR-0.1.0-SNAPSHOT`.
 
-Finally the Azure credentials have to be specified. 
+Finally the Azure credentials have to be specified.
 
 The following gives an example:
 
@@ -76,10 +67,7 @@ public class SendAzureMessage {
 
 [[receiving-messages]]
 == Receiving messages
-Messages can be received from Azure by creating an MDB (Message Driven Bean)
-that implements the `fish.payara.cloud.connectors.azuresb.api.AzureSBListener`
-marker interface and has a single method annotated with `@OnAzureSBMessage`
-and the method signature `void method(BrokeredMessage message)`.
+Messages can be received from Azure by creating an MDB (Message Driven Bean) that implements the `fish.payara.cloud.connectors.azuresb.api.AzureSBListener` marker interface and has a single method annotated with `@OnAzureSBMessage` and the method signature `void method(BrokeredMessage message)`.
 
 The following gives an example:
 

--- a/docs/modules/ROOT/pages/Technical Documentation/Ecosystem/Connector Suites/Cloud Connectors/Azure SB.adoc
+++ b/docs/modules/ROOT/pages/Technical Documentation/Ecosystem/Connector Suites/Cloud Connectors/Azure SB.adoc
@@ -4,6 +4,18 @@
 The Microsoft Azure Service Bus allows code that runs both outside and inside
 Azure to communicate with Azure.
 
+[[versioning]]
+== Versioning
+The tags below are for the https://github.com/payara/Cloud-Connectors[Cloud Connectors repository]. You should use the one corresponding to the Jakarta version you require.
+
+https://github.com/payara/Cloud-Connectors/releases/tag/0.8.0[0.8.0]:: Azure Service Bus Connector using JakartaEE 8 and the `javax` namespace
+https://github.com/payara/Cloud-Connectors/releases/tag/AzureServiceBus-1.0.0[AzureServiceBus-1.0.0]:: Azure Service Bus Connector using JakartaEE 10 and the `jakarta` namespace
+
+[[usage]]
+== Usage
+
+IMPORTANT: If you have selected to use Azure Service Bus Connector 1.0.0, replace all occurunces of `0.8.0` with `1.0.0` for the following example.
+
 In order to connect to Azure, the `azure-sb-rar-0.8.0.rar` has to
 be deployed as shown in the xref:Technical Documentation/Ecosystem/Connector Suites/Cloud Connectors/Overview.adoc#installing-a-connector[Installing a connector section] of the Cloud Connectors overview.
 

--- a/docs/modules/ROOT/pages/Technical Documentation/Ecosystem/Connector Suites/Cloud Connectors/Azure SB.adoc
+++ b/docs/modules/ROOT/pages/Technical Documentation/Ecosystem/Connector Suites/Cloud Connectors/Azure SB.adoc
@@ -1,3 +1,4 @@
+[[azuresb-connector]]
 = Azure Service Bus Cloud Connector
 
 The Microsoft Azure Service Bus allows code that runs both outside and inside
@@ -24,6 +25,7 @@ Note that this dependency have scope provided since the types within this
 dependency are globally available to every application deployed to Payara Micro
 after the `azure-sb-rar-0.8.0.rar` was deployed.
 
+[[sending-messages]]
 == Sending messages
 
 Sending messages to Azure can be done via the JCA and an Azure specific API. In
@@ -72,6 +74,7 @@ public class SendAzureMessage {
 }
 ----
 
+[[receiving-messages]]
 == Receiving messages
 Messages can be received from Azure by creating an MDB (Message Driven Bean)
 that implements the `fish.payara.cloud.connectors.azuresb.api.AzureSBListener`

--- a/docs/modules/ROOT/pages/Technical Documentation/Ecosystem/Connector Suites/Cloud Connectors/MQTT.adoc
+++ b/docs/modules/ROOT/pages/Technical Documentation/Ecosystem/Connector Suites/Cloud Connectors/MQTT.adoc
@@ -3,6 +3,18 @@
 
 MQTT (Message Queue Telemetry Transport) is a lightweight publish-subscribe messaging protocol.
 
+[[versioning]]
+== Versioning
+The tags below are for the https://github.com/payara/Cloud-Connectors[Cloud Connectors repository]. You should use the one corresponding to the Jakarta version you require.
+
+https://github.com/payara/Cloud-Connectors/releases/tag/0.8.0[0.8.0]:: MQTT Connector using JakartaEE 8 and the `javax` namespace
+https://github.com/payara/Cloud-Connectors/releases/tag/MQTT-1.0.0[MQTT-1.0.0]:: Azure Service Bus Connector using JakartaEE 10 and the `jakarta` namespace
+
+[[usage]]
+== Usage
+
+IMPORTANT: If you have selected to use MQTT Connector 1.0.0, replace all occurunces of `0.8.0` with `1.0.0` for the following example.
+
 In order to connect to a MQTT broker, the `mqtt-rar-0.8.0.rar` has to be deployed as shown in the xref:Technical Documentation/Ecosystem/Connector Suites/Cloud Connectors/Overview.adoc#installing-a-connector[Installing a connector section] of the Cloud Connectors overview.
 
 In order to make use of this connector in an application, the following Maven dependency is needed:

--- a/docs/modules/ROOT/pages/Technical Documentation/Ecosystem/Connector Suites/Cloud Connectors/MQTT.adoc
+++ b/docs/modules/ROOT/pages/Technical Documentation/Ecosystem/Connector Suites/Cloud Connectors/MQTT.adoc
@@ -1,3 +1,4 @@
+[[mqtt-connector]]
 = MQTT Cloud Connector
 
 MQTT (Message Queue Telemetry Transport) is a lightweight publish-subscribe messaging protocol.
@@ -19,6 +20,7 @@ In order to make use of this connector in an application, the following Maven de
 
 Note that this dependency have scope provided since the types within this dependency are globally available to every application deployed to Payara Micro after the `mqtt-rar-0.8.0.rar` was deployed.
 
+[[sending-messages]]
 == Sending messages
 Sending messages to a MQTT broker can be done via the JCA and an MQTT specific API. In order to start using this API to send messages, a resource has to be defined via the JCA API; a connection factory.
 
@@ -58,7 +60,7 @@ public class SendMQTTMessage {
 }
 ----
 
-
+[[receiving-messages]]
 == Receiving messages
 Messages can be received from an MQTT broker by creating an MDB (Message Driven Bean) that implements the `fish.payara.cloud.connectors.MQTT.api.MQTTListener` marker interface and has a single method annotated with `@OnMQTTMessage` and the method signature `void method(String topic, MqttMessage message)`.
 

--- a/docs/modules/ROOT/pages/Technical Documentation/Ecosystem/Connector Suites/Cloud Connectors/MQTT.adoc
+++ b/docs/modules/ROOT/pages/Technical Documentation/Ecosystem/Connector Suites/Cloud Connectors/MQTT.adoc
@@ -3,7 +3,7 @@
 
 MQTT (Message Queue Telemetry Transport) is a lightweight publish-subscribe messaging protocol.
 
-In order to connect to a MQTT broker, the `mqtt-rar-0.8.0.rar` has to be deployed as shown in the xref:/Technical Documentation/Ecosystem/Connector Suites/Cloud Connectors/Overview.adoc#Installing-a-connector[Installing a connector section] of the Cloud Connectors overview.
+In order to connect to a MQTT broker, the `mqtt-rar-0.8.0.rar` has to be deployed as shown in the xref:Technical Documentation/Ecosystem/Connector Suites/Cloud Connectors/Overview.adoc#installing-a-connector[Installing a connector section] of the Cloud Connectors overview.
 
 In order to make use of this connector in an application, the following Maven dependency is needed:
 


### PR DESCRIPTION
Fixes formatting, broken links and missing anchors for Cloud Connector documentation. Also documents alternative versions of the cloud connectors and what their key differences are