### PR TITLE
Remove Prerelease

### DIFF
--- a/community/docs/antora.yml
+++ b/community/docs/antora.yml
@@ -1,7 +1,6 @@
 name: docs
 title: Payara Platform
 version: master
-prerelease: true
 start_page: ROOT:Overview.adoc
 nav:
   - modules/ROOT/nav.adoc

--- a/docs/antora.yml
+++ b/docs/antora.yml
@@ -1,3 +1,2 @@
 name: docs
 version: master
-prerelease: true


### PR DESCRIPTION
As there are no more releases of Payara 5 Community, it makes sense to have Payara 6 now be the default for the documentation.