### PR TITLE
Update REST SSL Alias Configuration Extension to Latest Version

### DIFF
--- a/docs/modules/ROOT/pages/Technical Documentation/Ecosystem/Miscellaneous/JAX-RS Extension.adoc
+++ b/docs/modules/ROOT/pages/Technical Documentation/Ecosystem/Miscellaneous/JAX-RS Extension.adoc
@@ -14,7 +14,7 @@ To install this extension, simply include its JAR file in the application's WAR 
 <dependency>
   <groupId>fish.payara.ecosystem.jaxrs</groupId>
   <artifactId>rest-ssl-configuration</artifactId>
-  <version>1.0</version>
+  <version>1.2</version>
 </dependency>
 ----
 


### PR DESCRIPTION
Title.
1.2 has been out for quite a while: https://nexus.payara.fish/repository/payara-artifacts/fish/payara/ecosystem/jaxrs/rest-ssl-configuration/1.2/rest-ssl-configuration-1.2.jar