### PR TITLE
(Master) 5.49.0 Release Notes to Nav

### DIFF
--- a/enterprise/docs/modules/ROOT/partials/release-notes.adoc
+++ b/enterprise/docs/modules/ROOT/partials/release-notes.adoc
@@ -1,5 +1,6 @@
 .Release Notes
 * xref:Release Notes/Overview.adoc[Overview]
+* xref:Release Notes/Release Notes 5.49.0.adoc[Release Notes 5.49.0]
 * xref:Release Notes/Release Notes 5.48.1.adoc[Release Notes 5.48.1]
 * xref:Release Notes/Release Notes 5.48.0.adoc[Release Notes 5.48.0]
 * xref:Release Notes/Release Notes 5.47.0.adoc[Release Notes 5.47.0]


### PR DESCRIPTION
5.49.0 Release Notes are missing from the partial page and therefore the nav bar. This has already been fixed in e5.49.0, this is the fix for master.