### PR TITLE
FISH-6980 add ear libs to openapi scan

### DIFF
--- a/community/docs/modules/ROOT/pages/Technical Documentation/MicroProfile/OpenAPI.adoc
+++ b/community/docs/modules/ROOT/pages/Technical Documentation/MicroProfile/OpenAPI.adoc
@@ -83,7 +83,7 @@ In addition to the standard properties, the following properties have been added
 
 |===
 | Property key | Description
-| `mp.openapi.scan.lib`  |  Configuration property that allows the server to scan packaged JAR files inside the WAR's library directory (`WEB-INF/lib`). Default value is `false`.
+| `mp.openapi.extensions.scan.lib`  |  Configuration property that allows the server to scan packaged JAR files inside the WAR's library directory (`WEB-INF/lib`). If the WAR is inside EAR, the server scans also JAR files inside EAR's `lib/` directory. Default value is `false`.
 |===
 
 [[sources-model-reader]]

--- a/community/docs/modules/ROOT/pages/Technical Documentation/MicroProfile/OpenAPI.adoc
+++ b/community/docs/modules/ROOT/pages/Technical Documentation/MicroProfile/OpenAPI.adoc
@@ -36,7 +36,7 @@ MicroProfile OpenAPI specifies several ways of configuring the data in the produ
 ----
 
 [[sources-config]]
-=== Config Properties
+=== Configuration Properties
 
 The OpenAPI document generation process can be configured through the xref:Technical Documentation/MicroProfile/Config/Overview.adoc[Config API]. The following are the standard configuration properties as presented by the specification:
 
@@ -122,7 +122,6 @@ The following file names are allowed for this file. The file given must also be 
 
 |===
 | File Format | Allowed File Names
-
 | `yaml` | `openapi.yaml` `openapi.yml`
 | `json` | `openapi.json`
 |===
@@ -263,8 +262,7 @@ OpenAPI can be configured by using Admin Console or Asadmin commands.
 [[using-the-admin-console]]
 === Using the Admin Console
 
-To configure the OpenAPI in the Admin Console, go to Configuration 
-→ [instance-configuration (like server-config)] → MicroProfile → OpenAPI:
+To configure the OpenAPI in the Admin Console, go to Configuration → [instance-configuration (like server-config)] → MicroProfile → OpenAPI:
 
 image:microprofile/openapi.png[Set OpenAPI Configuration]
 
@@ -289,7 +287,7 @@ asadmin> set-openapi-configuration
 Enables or disables the OpenAPI service.
 
 [[configuration-note]]
-NOTE: When the OpenAPI service is disabled, the endpoint will always return a 403 error and any applications deployed during this period will *not* have an OpenAPI document built. Enabling the service again will not cause a documents to be built for any currently deployed applications.
+NOTE: When the OpenAPI service is disabled, the `/openapi` endpoint will always return a `403` error and any applications deployed during this period will *not* have an OpenAPI document built. Enabling the service again will not cause a documents to be built for any currently deployed applications.
 
 ===== Command Options
 
@@ -315,7 +313,7 @@ NOTE: When the OpenAPI service is disabled, the endpoint will always return a 40
 
 |`securityenabled`
 |Boolean
-|Whether or not secure access to the endpoint is enabled.
+|Whether or not secure access to the OpenAPI endpoint is enabled.
 |false
 |No
 
@@ -327,7 +325,7 @@ NOTE: When the OpenAPI service is disabled, the endpoint will always return a 40
 
 |`endpoint`
 |String
-|The context root used to expose the service endpoint.
+|The context root used to expose the OpenAPI endpoint.
 |`openapi`
 |No
 


### PR DESCRIPTION
Fix `mp.openapi.extensions.scan.lib` property name
Update scanning of jars in ear's `lib/` directory, change introduced in FISH-6980