### PR TITLE
Upgrade Tool Caveat (Payara6)

### DIFF
--- a/enterprise/docs/modules/ROOT/pages/Technical Documentation/Payara Server Documentation/Upgrade Payara/Upgrade Tool.adoc
+++ b/enterprise/docs/modules/ROOT/pages/Technical Documentation/Payara Server Documentation/Upgrade Payara/Upgrade Tool.adoc
@@ -7,7 +7,7 @@ This upgrade path will be implemented in a future release of the tool and Server
 
 This tool can be used to upgrade an existing Payara Server installation to a newer version. The Upgrade Tool is bundled in Payara Server by default and is maintained as a separate JAR artifact under the `fish.payara.extras:payara-upgrade-tool` GAV coordinates.
 
-TIP: The upgrade tool can be manually upgraded to a newer version in case it is needed. To do so, download the latest JAR release from Nexus using https://nexus.payara.fish/#browse/browse:payara-enterprise-downloadable-artifacts:fish%2Fpayara%2Fextras%2Fpayara-upgrade-tool[this link] and then replace the older version into your Payara Server installation under the `${PAYARA_SERVER_INSTALL}/glassfish/lib/asadmin` folder.
+TIP: The upgrade tool can be manually upgraded to a newer version in case it is needed. To do so, download the latest 2.x JAR release from Nexus using https://nexus.payara.fish/#browse/browse:payara-enterprise-downloadable-artifacts:fish%2Fpayara%2Fextras%2Fpayara-upgrade-tool[this link] and then replace the older version into your Payara Server installation under the `${PAYARA_SERVER_INSTALL}/glassfish/lib/asadmin` folder.
 
 [[commands]]
 == Asadmin CLI Commands


### PR DESCRIPTION
Add caveat informing users to use 2.x releases of the upgrade tool for Payara 6