### PR TITLE
Option server-name-enabled is called server-header

### DIFF
--- a/docs/modules/ROOT/pages/Technical Documentation/Payara Server Documentation/Server Configuration And Management/HTTP Service/Protocols.adoc
+++ b/docs/modules/ROOT/pages/Technical Documentation/Payara Server Documentation/Server Configuration And Management/HTTP Service/Protocols.adoc
@@ -38,7 +38,7 @@ The name of the server. This will be sent as the `Server` header in responses.
 
 [source, shell]
 ----
-set configs.config.server-config.network-config.protocols.protocol.${protocol-name}.http.server-name-enabled=value
+set configs.config.server-config.network-config.protocols.protocol.${protocol-name}.http.server-header=value
 ----
 
 [[configuration-http-default-virtual-server]]


### PR DESCRIPTION
Hello, we wanted to hide the `xpowered-by` header and saw that we can also hide the `server` header.
However, it seems the option for the `server`-Header in the docs is wrong. By setting it via Web-UI and checking the resulting `domain.xml`, it seems to be `server-header` instead of `server-name-enabled`.

Tested with the full payara distribution versions:
- 5.2020.6
- 5.2022.3
- 6.2023.4

I did not test it with the latest release, 6.2022.6.