### PR TITLE
FISH-7740 Document Updated Default JVM_ARGS for Payara Micro Docker Image

### DIFF
--- a/enterprise/docs/modules/ROOT/pages/Technical Documentation/Payara Micro Documentation/Payara Micro Docker Image.adoc
+++ b/enterprise/docs/modules/ROOT/pages/Technical Documentation/Payara Micro Documentation/Payara Micro Docker Image.adoc
@@ -207,7 +207,7 @@ The following environment variables can be used to configure multiple settings o
 |Name |Description |Default Value
 |`MEM_MAX_RAM_PERCENTAGE`| Value for the JVM argument `-XX:MaxRAMPercentage` which indicates the percentage of memory assigned to the container that can be used by the Java process| `70`
 |`MEM_XSS`| Value for the JVM argument `-Xss` which controls the stack size| `512K`
-|`JVM_ARGS`| Additional JVM arguments which will be used to configure the Payara Servers DAS JVM settings|
+|`JVM_ARGS`| Additional JVM arguments which will be used to configure the Payara Servers DAS JVM settings| `-Djdk.util.zip.disableZip64ExtraFieldValidation=true`
 |===
 
 The following is a list of variables used by the Docker image to set up the Payara Micro instance startup, so it is not recommended to alter their values:


### PR DESCRIPTION
Updates the default JVM_ARGS for the Payara Micro Docker image as per https://github.com/payara/Payara-Enterprise/pull/933