### PR TITLE
FISH-6519 Add useBundledJsf EAR Comment

### DIFF
--- a/docs/modules/ROOT/pages/Technical Documentation/Payara Server Documentation/Server Configuration And Management/Classloading/Enhanced Classloading.adoc
+++ b/docs/modules/ROOT/pages/Technical Documentation/Payara Server Documentation/Server Configuration And Management/Classloading/Enhanced Classloading.adoc
@@ -91,6 +91,8 @@ You need to indicate within the _payara-web.xml_ (or glassfish-web.xml) file tha
 
 By specifying these options, the bundled JSF implementation within your deployment (WAR or EAR) will be used correctly.
 
+IMPORTANT: If using an EAR you must bundle the JSF implementation within the embedded WAR component. You cannot add the JSF implementation as an EAR library.
+
 [[extreme-classloading-isolation]]
 == Extreme Classloading Isolation
 


### PR DESCRIPTION
Adds a comment that you cannot use a bundled JSF implementation as an EAR library.

Related PR: https://github.com/payara/Payara-Enterprise/pull/962