### PR TITLE
FISH-7833: adding list of fixed cve's by upgrading okhttp

### DIFF
--- a/community/docs/modules/ROOT/pages/Security/Security Fix List.adoc
+++ b/community/docs/modules/ROOT/pages/Security/Security Fix List.adoc
@@ -7,9 +7,9 @@ The following is a list of reported _**C**ommon **V**ulnerabilities and **E**xpo
 |=======================================================================
 |ID |CVSS v3.0 Base Score |Status |Summary |Release |Pull Requests |Observations
 
-|https://nvd.nist.gov/vuln/detail/CVE-2023-0833[CVE-2023-0833] | 5.5 | FIXED | A flaw was found in Red Hat's AMQ-Streams, which ships a version of the OKHttp component with an information disclosure flaw via an exception triggered by a header containing an illegal value. |6.2024.1 | https://github.com/payara/Payara/pull/6507[#6507] | Fixed by okhttp Upgrade
+|https://nvd.nist.gov/vuln/detail/CVE-2023-0833[CVE-2023-0833] | 5.5 | FIXED | A flaw was found in Red Hat's AMQ-Streams, which ships a version of the OKHttp component with an information disclosure flaw via an exception triggered by a header containing an illegal value. |6.2024.1 | https://github.com/payara/Payara/pull/6507[#6507] | Fixed by OKHttp Upgrade
 
-|https://nvd.nist.gov/vuln/detail/CVE-2023-3635[CVE-2023-3635] | 7.5 | FIXED | GzipSource does not handle an exception that might be raised when parsing a malformed gzip buffer. . This may lead to denial of service of the Okio client. | 6.2024.1 | https://github.com/payara/Payara/pull/6507[#6507] | Fixed by okhttp Upgrade
+|https://nvd.nist.gov/vuln/detail/CVE-2023-3635[CVE-2023-3635] | 7.5 | FIXED | GzipSource does not handle an exception that might be raised when parsing a malformed gzip buffer. This may lead to denial of service of the Okio client. | 6.2024.1 | https://github.com/payara/Payara/pull/6507[#6507] | Fixed by OKHttp Upgrade
 
 |https://nvd.nist.gov/vuln/detail/CVE-2021-36374[CVE-2021-36374] | 5.5 | FIXED | A specially crafted ZIP archive can cause an out of memory error | 6.2023.12 | https://github.com/payara/Payara/pull/6481[#6481] | Fixed by Apache Ant upgrade
 

--- a/community/docs/modules/ROOT/pages/Security/Security Fix List.adoc
+++ b/community/docs/modules/ROOT/pages/Security/Security Fix List.adoc
@@ -7,6 +7,10 @@ The following is a list of reported _**C**ommon **V**ulnerabilities and **E**xpo
 |=======================================================================
 |ID |CVSS v3.0 Base Score |Status |Summary |Release |Pull Requests |Observations
 
+|https://nvd.nist.gov/vuln/detail/CVE-2023-0833[CVE-2023-0833] | 5.5 | FIXED | A flaw was found in Red Hat's AMQ-Streams, which ships a version of the OKHttp component with an information disclosure flaw via an exception triggered by a header containing an illegal value. |6.2024.1 | https://github.com/payara/Payara/pull/6507[#6507] | Fixed by okhttp Upgrade
+
+|https://nvd.nist.gov/vuln/detail/CVE-2023-3635[CVE-2023-3635] | 7.5 | FIXED | GzipSource does not handle an exception that might be raised when parsing a malformed gzip buffer. . This may lead to denial of service of the Okio client. | 6.2024.1 | https://github.com/payara/Payara/pull/6507[#6507] | Fixed by okhttp Upgrade
+
 |https://nvd.nist.gov/vuln/detail/CVE-2021-36374[CVE-2021-36374] | 5.5 | FIXED | A specially crafted ZIP archive can cause an out of memory error | 6.2023.12 | https://github.com/payara/Payara/pull/6481[#6481] | Fixed by Apache Ant upgrade
 
 |https://nvd.nist.gov/vuln/detail/CVE-2021-36373[CVE-2021-36373] | 5.5 | FIXED | A specially crafted TAR archive can cause an out of memory error | 6.2023.12 | https://github.com/payara/Payara/pull/6481[#6481] | Fixed by Apache Ant upgrade

--- a/enterprise/docs/modules/ROOT/pages/Security/Security Fix List.adoc
+++ b/enterprise/docs/modules/ROOT/pages/Security/Security Fix List.adoc
@@ -7,6 +7,10 @@ The following is a list of reported _**C**ommon **V**ulnerabilities and **E**xpo
 |=======================================================================
 |ID |CVSS v3.0 Base Score |Status |Summary |Release |Observations
 
+|https://nvd.nist.gov/vuln/detail/CVE-2023-0833[CVE-2023-0833] | 5.5 | FIXED | A flaw was found in Red Hat's AMQ-Streams, which ships a version of the OKHttp component with an information disclosure flaw via an exception triggered by a header containing an illegal value. |6.10.0 | Fixed by OKHttp Upgrade
+
+|https://nvd.nist.gov/vuln/detail/CVE-2023-3635[CVE-2023-3635] | 7.5 | FIXED | GzipSource does not handle an exception that might be raised when parsing a malformed gzip buffer. This may lead to denial of service of the Okio client. | 6.10.0 | Fixed by OKHttp Upgrade
+
 |https://nvd.nist.gov/vuln/detail/CVE-2021-36374[CVE-2021-36374] | 5.5 | FIXED | A specially crafted ZIP archive can cause an out of memory error | 6.9.0 | Fixed by Apache Ant upgrade
 
 |https://nvd.nist.gov/vuln/detail/CVE-2021-36373[CVE-2021-36373] | 5.5 | FIXED | A specially crafted TAR archive can cause an out of memory error | 6.9.0 | Fixed by Apache Ant upgrade


### PR DESCRIPTION
Adding list of cve's fixed by okhttp upgrade