### PR TITLE
Fixed glassfish3 path references

### DIFF
--- a/docs/modules/ROOT/pages/Technical Documentation/Payara Server Documentation/Command Reference/collect-log-files.adoc
+++ b/docs/modules/ROOT/pages/Technical Documentation/Payara Server Documentation/Command Reference/collect-log-files.adoc
@@ -71,7 +71,7 @@ This example generates a ZIP archive from the log files for the default server.
 [source,shell]
 ----
 asadmin> collect-log-files
-Created Zip file under /space/gfv3/v3setup/glassfish3/glassfish/domains/domain1/\
+Created Zip file under /space/gfv3/v3setup/payara6/glassfish/domains/domain1/\
 collected-logs/log_2010-12-15_15-46-23.zip.
 Command collect-log-files executed successfully.
 ----
@@ -86,7 +86,7 @@ This example generates a ZIP archive from the log files for a cluster named `clu
 asadmin> collect-log-files --target cluster1
 Log files are downloaded for instance1.
 Log files are downloaded for instance2.
-Created Zip file under /space/gfv3/v3setup/glassfish3/glassfish/domains/domain1/\
+Created Zip file under /space/gfv3/v3setup/payara6/glassfish/domains/domain1/\
 collected-logs/log_2010-12-15_15-54-06.zip.
 Command collect-log-files executed successfully.
 ----

--- a/docs/modules/ROOT/pages/Technical Documentation/Payara Server Documentation/Command Reference/create-service.adoc
+++ b/docs/modules/ROOT/pages/Technical Documentation/Payara Server Documentation/Command Reference/create-service.adoc
@@ -212,7 +212,7 @@ Configuration location of the service:/home/gfuser/glassfish-installations
 /payara6/glassfish/domains
 Manifest file location on the system:/var/svc/manifest/application
 /GlassFish/domain1_home_gfuser_glassfish-installations_payara6
-_glassfish_domains/Domain-service-smf.xml.
+_payara_domains/Domain-service-smf.xml.
 You have created the service but you need to start it yourself. 
 Here are the most typical Solaris commands of interest:
 * /usr/bin/svcs -a | grep domain1 // status

--- a/docs/modules/ROOT/pages/Technical Documentation/Payara Server Documentation/Command Reference/create-service.adoc
+++ b/docs/modules/ROOT/pages/Technical Documentation/Payara Server Documentation/Command Reference/create-service.adoc
@@ -156,16 +156,16 @@ The Windows Service was created successfully.  It is ready to be started.  Here 
 the details:
 ID of the service: domain1
 Display Name of the service:domain1 GlassFish Server
-Domain Directory: C:\glassfish3\glassfish\domains\domain1
-Configuration file for Windows Services Wrapper: C:\glassfish3\glassfish\domains\
+Domain Directory: C:\payara6\glassfish\domains\domain1
+Configuration file for Windows Services Wrapper: C:\payara6\glassfish\domains\
 domain1\bin\domain1Service.xml
 The service can be controlled using the Windows Services Manager or you can use the
 Windows Services Wrapper instead:
-Start Command:  C:\glassfish3\glassfish\domains\domain1\bin\domain1Service.exe  start
-Stop Command:   C:\glassfish3\glassfish\domains\domain1\bin\domain1Service.exe  stop
-Uninstall Command:  C:\glassfish3\glassfish\domains\domain1\bin\domain1Service.exe
+Start Command:  C:\payara6\glassfish\domains\domain1\bin\domain1Service.exe  start
+Stop Command:   C:\payara6\glassfish\domains\domain1\bin\domain1Service.exe  stop
+Uninstall Command:  C:\payara6\glassfish\domains\domain1\bin\domain1Service.exe
 uninstall
-Install Command:  C:\glassfish3\glassfish\domains\domain1\bin\domain1Service.exe
+Install Command:  C:\payara6\glassfish\domains\domain1\bin\domain1Service.exe
 install
 
 This message is also available in a file named PlatformServices.log in the domain's 
@@ -194,7 +194,7 @@ Here are the most typical Linux commands of interest:
 * /etc/init.d/GlassFish_domain1 restart
 
 For your convenience this message has also been saved to this file: 
-/export/glassfish3/glassfish/domains/domain1/PlatformServices.log
+/export/payara6/glassfish/domains/domain1/PlatformServices.log
 Command create-service executed successfully.
 ----
 
@@ -209,9 +209,9 @@ The Service was created successfully. Here are the details:
 Name of the service:application/GlassFish/domain1
 Type of the service:Domain
 Configuration location of the service:/home/gfuser/glassfish-installations
-/glassfish3/glassfish/domains
+/payara6/glassfish/domains
 Manifest file location on the system:/var/svc/manifest/application
-/GlassFish/domain1_home_gfuser_glassfish-installations_glassfish3
+/GlassFish/domain1_home_gfuser_glassfish-installations_payara6
 _glassfish_domains/Domain-service-smf.xml.
 You have created the service but you need to start it yourself. 
 Here are the most typical Solaris commands of interest:

--- a/docs/modules/ROOT/pages/Technical Documentation/Payara Server Documentation/Command Reference/export-sync-bundle.adoc
+++ b/docs/modules/ROOT/pages/Technical Documentation/Payara Server Documentation/Command Reference/export-sync-bundle.adoc
@@ -87,7 +87,7 @@ This example exports the configuration data of the cluster `pmdcluster`.
 [source,shell]
 ----
 asadmin> export-sync-bundle --target=pmdcluster
-Sync bundle: /export/glassfish3/glassfish/domains/domain1/sync/
+Sync bundle: /export/payara6/glassfish/domains/domain1/sync/
 pmdcluster-sync-bundle.zip
 
 Command export-sync-bundle executed successfully.

--- a/docs/modules/ROOT/pages/Technical Documentation/Payara Server Documentation/Command Reference/import-sync-bundle.adoc
+++ b/docs/modules/ROOT/pages/Technical Documentation/Payara Server Documentation/Command Reference/import-sync-bundle.adoc
@@ -63,14 +63,14 @@ file-name::
 
 *Example 1 Importing Configuration Data for a Clustered Instance*
 
-This example imports the configuration for the clustered instance `ymli2` on the node `sj02` from the archive file `/export/glassfish3/glassfish/domains/domain1/sync/ymlcluster-sync-bundle.zip`.
+This example imports the configuration for the clustered instance `ymli2` on the node `sj02` from the archive file `/export/payara6/glassfish/domains/domain1/sync/ymlcluster-sync-bundle.zip`.
 
 The command is run on the host `sj02`, which is the host that the node `sj02` represents. The DAS is running on the host `sr04` and uses the default HTTP port for administration.
 
 [source,shell]
 ----
 sj02# asadmin --host sr04 import-sync-bundle --node sj02 --instance ymli2 
-/export/glassfish3/glassfish/domains/domain1/sync/ymlcluster-sync-bundle.zip
+/export/payara6/glassfish/domains/domain1/sync/ymlcluster-sync-bundle.zip
 Command import-sync-bundle executed successfully.
 ----
 

--- a/docs/modules/ROOT/pages/Technical Documentation/Payara Server Documentation/Command Reference/install-node-dcom.adoc
+++ b/docs/modules/ROOT/pages/Technical Documentation/Payara Server Documentation/Command Reference/install-node-dcom.adoc
@@ -65,7 +65,7 @@ asadmin-options::
   `true`;;
     The archive file is saved.
 `--installdir`::
-  The absolute path to the parent of the base installation directory where the Payara Server software is to be installed on each host, for example, `C:\glassfish3`. If the directory does not exist, the subcommand creates the directory. +
+  The absolute path to the parent of the base installation directory where the Payara Server software is to be installed on each host, for example, `C:\payara6`. If the directory does not exist, the subcommand creates the directory. +
   The user that is running this subcommand must have write access to the specified directory. Otherwise, an error occurs. +
   To overwrite an existing an installation of the Payara Server software, set the `--force` option to `true`. If the directory already contains an installation and the `--force` option is `false`, an error occurs. +
   The default is the parent of the base installation directory of the Payara Server software on the host where this subcommand is run.
@@ -103,14 +103,14 @@ asadmin> install-node-dcom wpmdl1.example.com wpmdl2.example.com
 Created installation zip C:\glassfish8107276692860773166.zip
 Copying 85760199 bytes..........................................................
 ....................................
-WROTE FILE TO REMOTE SYSTEM: C:/glassfish3/glassfish_install.zip and C:/glassfish3/unpack.bat
+WROTE FILE TO REMOTE SYSTEM: C:/payara6/glassfish_install.zip and C:/payara6/unpack.bat
 Output from Windows Unpacker:
  
 C:\Windows\system32>C:
  
-C:\Windows\system32>cd "C:\glassfish3"
+C:\Windows\system32>cd "C:\payara6"
  
-C:\glassfish3>jar xvf glassfish_install.zip
+C:\payara6>jar xvf glassfish_install.zip
  inflated: bin/asadmin
  inflated: bin/asadmin.bat
  inflated: glassfish/bin/appclient

--- a/docs/modules/ROOT/pages/Technical Documentation/Payara Server Documentation/Command Reference/install-node-ssh.adoc
+++ b/docs/modules/ROOT/pages/Technical Documentation/Payara Server Documentation/Command Reference/install-node-ssh.adoc
@@ -78,7 +78,7 @@ asadmin-options::
     The archive file is saved.
 `--installdir`::
   The absolute path to the parent of the base installation directory where the Payara Server software is to be installed on each host,
-  for example, `/export/glassfish3/`. If the directory does not exist, the subcommand creates the directory. +
+  for example, `/export/payara6/`. If the directory does not exist, the subcommand creates the directory. +
   The user that is running this subcommand must have write access to the specified directory. Otherwise, an error occurs. +
   To overwrite an existing an installation of the Payara Server software, set the `--force` option to `true`. If the directory already
   contains an installation and the `--force` option is `false`, an error occurs. +
@@ -125,17 +125,17 @@ Created installation zip /home/gfuser/glassfish2339538623689073993.zip
 Successfully connected to gfuser@sj03.example.com using keyfile /home/gfuser
 /.ssh/id_rsa
 Copying /home/gfuser/glassfish2339538623689073993.zip (81395008 bytes) to 
-sj03.example.com:/export/glassfish3
-Installing glassfish2339538623689073993.zip into sj03.example.com:/export/glassfish3
-Removing sj03.example.com:/export/glassfish3/glassfish2339538623689073993.zip
-Fixing file permissions of all files under sj03.example.com:/export/glassfish3/bin
+sj03.example.com:/export/payara6
+Installing glassfish2339538623689073993.zip into sj03.example.com:/export/payara6
+Removing sj03.example.com:/export/payara6/glassfish2339538623689073993.zip
+Fixing file permissions of all files under sj03.example.com:/export/payara6/bin
 Successfully connected to gfuser@sj04.example.com using keyfile /home/gfuser
 /.ssh/id_rsa
 Copying /home/gfuser/glassfish2339538623689073993.zip (81395008 bytes) to 
-sj04.example.com:/export/glassfish3
-Installing glassfish2339538623689073993.zip into sj04.example.com:/export/glassfish3
-Removing sj04.example.com:/export/glassfish3/glassfish2339538623689073993.zip
-Fixing file permissions of all files under sj04.example.com:/export/glassfish3/bin
+sj04.example.com:/export/payara6
+Installing glassfish2339538623689073993.zip into sj04.example.com:/export/payara6
+Removing sj04.example.com:/export/payara6/glassfish2339538623689073993.zip
+Fixing file permissions of all files under sj04.example.com:/export/payara6/bin
 Command install-node-ssh executed successfully
 ----
 

--- a/docs/modules/ROOT/pages/Technical Documentation/Payara Server Documentation/Command Reference/install-node.adoc
+++ b/docs/modules/ROOT/pages/Technical Documentation/Payara Server Documentation/Command Reference/install-node.adoc
@@ -67,7 +67,7 @@ asadmin-options::
   `true`;;
     The archive file is saved.
 `--installdir`::
-  The absolute path to the parent of the base installation directory where the Payara Server software is to be installed on each host, for example, `/export/glassfish3/`. If the directory does not exist, the subcommand creates the directory. +
+  The absolute path to the parent of the base installation directory where the Payara Server software is to be installed on each host, for example, `/export/payara6/`. If the directory does not exist, the subcommand creates the directory. +
   The user that is running this subcommand must have write access to the specified directory. Otherwise, an error occurs. +
   To overwrite an existing an installation of the Payara Server software, set the `--force` option to `true`. If the directory already contains an installation and the `--force` option is `false`, an error occurs. +
   The default is the parent of the base installation directory of the Payara Server software on the host where this subcommand is run.
@@ -109,17 +109,17 @@ Created installation zip /home/gfuser/glassfish2339538623689073993.zip
 Successfully connected to gfuser@sj03.example.com using keyfile /home/gfuser
 /.ssh/id_rsa
 Copying /home/gfuser/glassfish2339538623689073993.zip (81395008 bytes) to 
-sj03.example.com:/export/glassfish3
-Installing glassfish2339538623689073993.zip into sj03.example.com:/export/glassfish3
-Removing sj03.example.com:/export/glassfish3/glassfish2339538623689073993.zip
-Fixing file permissions of all files under sj03.example.com:/export/glassfish3/bin
+sj03.example.com:/export/payara6
+Installing glassfish2339538623689073993.zip into sj03.example.com:/export/payara6
+Removing sj03.example.com:/export/payara6/glassfish2339538623689073993.zip
+Fixing file permissions of all files under sj03.example.com:/export/payara6/bin
 Successfully connected to gfuser@sj04.example.com using keyfile /home/gfuser
 /.ssh/id_rsa
 Copying /home/gfuser/glassfish2339538623689073993.zip (81395008 bytes) to 
-sj04.example.com:/export/glassfish3
-Installing glassfish2339538623689073993.zip into sj04.example.com:/export/glassfish3
-Removing sj04.example.com:/export/glassfish3/glassfish2339538623689073993.zip
-Fixing file permissions of all files under sj04.example.com:/export/glassfish3/bin
+sj04.example.com:/export/payara6
+Installing glassfish2339538623689073993.zip into sj04.example.com:/export/payara6
+Removing sj04.example.com:/export/payara6/glassfish2339538623689073993.zip
+Fixing file permissions of all files under sj04.example.com:/export/payara6/bin
 Command install-node executed successfully
 ----
 

--- a/docs/modules/ROOT/pages/Technical Documentation/Payara Server Documentation/Command Reference/list-nodes-config.adoc
+++ b/docs/modules/ROOT/pages/Technical Documentation/Payara Server Documentation/Command Reference/list-nodes-config.adoc
@@ -91,8 +91,8 @@ remote communication in the domain `domain1`in long format.
 ----
 asadmin> list-nodes-config --long=true
 NODE NAME           TYPE     NODE HOST   INSTALL DIRECTORY    REFERENCED BY  
-localhost-domain1   CONFIG   localhost   /export/glassfish3                  
-devnode             CONFIG   localhost   /export/glassfish3   pmdsa1         
+localhost-domain1   CONFIG   localhost   /export/payara6
+devnode             CONFIG   localhost   /export/payara6   pmdsa1
 Command list-nodes-config executed successfully.
 ----
 

--- a/docs/modules/ROOT/pages/Technical Documentation/Payara Server Documentation/Command Reference/list-nodes-dcom.adoc
+++ b/docs/modules/ROOT/pages/Technical Documentation/Payara Server Documentation/Command Reference/list-nodes-dcom.adoc
@@ -94,9 +94,9 @@ communication over DCOM in a domain in long format.
 ----
 asadmin> list-nodes-dcom --long=true
 NODE NAME    TYPE   NODE HOST            INSTALL DIRECTORY   REFERENCED BY
-xkyd         DCOM   xkyd.example.com     C:\glassfish3
-wpmdl2       DCOM   wpmdl2.example.com   C:\glassfish3       wdi2
-wpmdl1       DCOM   wpmdl1.example.com   C:\glassfish3       wdi1
+xkyd         DCOM   xkyd.example.com     C:\payara6
+wpmdl2       DCOM   wpmdl2.example.com   C:\payara6       wdi2
+wpmdl1       DCOM   wpmdl1.example.com   C:\payara6       wdi1
 Command list-nodes-dcom executed successfully.
 ----
 

--- a/docs/modules/ROOT/pages/Technical Documentation/Payara Server Documentation/Command Reference/list-nodes-ssh.adoc
+++ b/docs/modules/ROOT/pages/Technical Documentation/Payara Server Documentation/Command Reference/list-nodes-ssh.adoc
@@ -91,8 +91,8 @@ This example lists the Payara Server nodes that support communication over SSH i
 ----
 asadmin> list-nodes-ssh --long=true
 NODE NAME   TYPE   NODE HOST          INSTALL DIRECTORY    REFERENCED BY           
-sj02        SSH    sj02.example.com   /export/glassfish3   pmd-i-sj02, yml-i-sj02  
-sj01        SSH    sj01.example.com   /export/glassfish3   pmd-i-sj01, yml-i-sj01  
+sj02        SSH    sj02.example.com   /export/payara6   pmd-i-sj02, yml-i-sj02
+sj01        SSH    sj01.example.com   /export/payara6   pmd-i-sj01, yml-i-sj01
 Command list-nodes-ssh executed successfully.
 ----
 

--- a/docs/modules/ROOT/pages/Technical Documentation/Payara Server Documentation/Command Reference/list-nodes.adoc
+++ b/docs/modules/ROOT/pages/Technical Documentation/Payara Server Documentation/Command Reference/list-nodes.adoc
@@ -95,10 +95,10 @@ This example lists the Payara Server nodes in the domain `domain1` in long forma
 ----
 asadmin> list-nodes --long=true
 NODE NAME           TYPE     NODE HOST          INSTALL DIRECTORY     REFERENCED BY
-localhost-domain1   CONFIG   localhost          /export/glassfish3                 
-sj02                SSH      sj02.example.com   /export/glassfish3    pmd-i2, yml-i2
-sj01                SSH      sj01.example.com   /export/glassfish3    pmd-i1, yml-i1
-devnode             CONFIG   localhost          /export/glassfish3    pmdsa1
+localhost-domain1   CONFIG   localhost          /export/payara6
+sj02                SSH      sj02.example.com   /export/payara6    pmd-i2, yml-i2
+sj01                SSH      sj01.example.com   /export/payara6    pmd-i1, yml-i1
+devnode             CONFIG   localhost          /export/payara6    pmdsa1
 Command list-nodes executed successfully.
 ----
 

--- a/docs/modules/ROOT/pages/Technical Documentation/Payara Server Documentation/Command Reference/start-instance.adoc
+++ b/docs/modules/ROOT/pages/Technical Documentation/Payara Server Documentation/Command Reference/start-instance.adoc
@@ -83,8 +83,8 @@ This example starts the Payara Server instance `pmdsa1`.
 asadmin> start-instance pmdsa1
 Waiting for the server to start ..............................
 Successfully started the instance: pmdsa1
-instance Location: /export/glassfish3/glassfish/nodes/localhost/pmdsa1
-Log File: /export/glassfish3/glassfish/nodes/localhost/pmdsa1/logs/server.log
+instance Location: /export/payara6/glassfish/nodes/localhost/pmdsa1
+Log File: /export/payara6/glassfish/nodes/localhost/pmdsa1/logs/server.log
 Admin Port: 24848
 Command start-local-instance executed successfully.
 The instance, pmdsa1, was started on host localhost
@@ -101,8 +101,8 @@ This example starts the Payara Server instance `ymlsa1` with JPDA debugging enab
 asadmin> start-instance --debug=true ymlsa1
 Waiting for the server to start ...............................
 Successfully started the instance: ymlsa1
-instance Location: /export/glassfish3/glassfish/nodes/localhost/ymlsa1
-Log File: /export/glassfish3/glassfish/nodes/localhost/ymlsa1/logs/server.log
+instance Location: /export/payara6/glassfish/nodes/localhost/ymlsa1
+Log File: /export/payara6/glassfish/nodes/localhost/ymlsa1/logs/server.log
 Admin Port: 24849
 Debugging is enabled. The debugging port is: 29010
 Command start-local-instance executed successfully.

--- a/docs/modules/ROOT/pages/Technical Documentation/Payara Server Documentation/Command Reference/start-local-instance.adoc
+++ b/docs/modules/ROOT/pages/Technical Documentation/Payara Server Documentation/Command Reference/start-local-instance.adoc
@@ -124,8 +124,8 @@ This example starts the instance `yml-i-sj01` on the host where the subcommand i
 asadmin> start-local-instance --node sj01 yml-i-sj01
 Waiting for the server to start .................................
 Successfully started the instance: yml-i-sj01
-instance Location: /export/glassfish3/glassfish/nodes/sj01/yml-i-sj01
-Log File: /export/glassfish3/glassfish/nodes/sj01/yml-i-sj01/logs/server.log
+instance Location: /export/payara6/glassfish/nodes/sj01/yml-i-sj01
+Log File: /export/payara6/glassfish/nodes/sj01/yml-i-sj01/logs/server.log
 Admin Port: 24849
 Command start-local-instance executed successfully.
 ----

--- a/docs/modules/ROOT/pages/Technical Documentation/Payara Server Documentation/Command Reference/uninstall-node-dcom.adoc
+++ b/docs/modules/ROOT/pages/Technical Documentation/Payara Server Documentation/Command Reference/uninstall-node-dcom.adoc
@@ -50,7 +50,7 @@ asadmin-options::
 `-?`::
   Displays the help text for the subcommand.
 `--installdir`::
-  The absolute path to the parent of the base installation directory where the Payara Server software is installed on each host, for example, `C:\glassfish3`. +
+  The absolute path to the parent of the base installation directory where the Payara Server software is installed on each host, for example, `C:\payara6`. +
   The user that is running this subcommand must have write access to the specified directory. Otherwise, an error occurs. +
   The specified directory must contain the installation of the Payara Server software on the host. Otherwise, an error occurs. +
   The default is the parent of the base installation directory of the Payara Server software on the host where this subcommand is run.
@@ -95,11 +95,11 @@ Command uninstall-node-dcom executed successfully.
 
 This example uninstalls Payara Server software on the host `xkyd.example.com`.
 
-The software is uninstalled even if a user-defined node resides on the host. The entire content of the `C:\glassfish3` directory is removed.
+The software is uninstalled even if a user-defined node resides on the host. The entire content of the `C:\payara6` directory is removed.
 
 [source,shell]
 ----
-asadmin> uninstall-node-dcom --force --installdir C:\glassfish3 xkyd.example.com
+asadmin> uninstall-node-dcom --force --installdir C:\payara6 xkyd.example.com
 Command uninstall-node-dcom executed successfully.
 ----
 

--- a/docs/modules/ROOT/pages/Technical Documentation/Payara Server Documentation/Command Reference/uninstall-node-ssh.adoc
+++ b/docs/modules/ROOT/pages/Technical Documentation/Payara Server Documentation/Command Reference/uninstall-node-ssh.adoc
@@ -54,7 +54,7 @@ asadmin-options::
 `-?`::
   Displays the help text for the subcommand.
 `--installdir`::
-  The absolute path to the parent of the base installation directory where the Payara Server software is installed on each host, for example, `/export/glassfish3/`. +
+  The absolute path to the parent of the base installation directory where the Payara Server software is installed on each host, for example, `/export/payara6/`. +
   The user that is running this subcommand must have write access to the specified directory. Otherwise, an error occurs. +
   The specified directory must contain the installation of the Payara Server software on the host. Otherwise, an error occurs. +
   The default is the parent of the base installation directory of the Payara Server software on the host where this subcommand is run.
@@ -111,21 +111,21 @@ Command uninstall-node-ssh executed successfully.
 
 This example uninstalls Payara Server software on the host `sj02.example.com`.
 
-The software is uninstalled even if a user-defined node resides on the host. The entire content of the `/export/glassfish3` directory is removed.
+The software is uninstalled even if a user-defined node resides on the host. The entire content of the `/export/payara6` directory is removed.
 
 Some lines of output are omitted from this example for readability.
 
 [source,shell]
 ----
-asadmin> uninstall-node-ssh --force --installdir /export/glassfish3 sj02.example.com
+asadmin> uninstall-node-ssh --force --installdir /export/payara6 sj02.example.com
 Successfully connected to gfuser@sj02.example.com using keyfile /home/gfuser
 /.ssh/id_rsa
-Force removing file /export/glassfish3/mq/lib/help/en/add_overrides.htm
-Force removing file /export/glassfish3/mq/lib/help/en/add_connfact.htm
+Force removing file /export/payara6/mq/lib/help/en/add_overrides.htm
+Force removing file /export/payara6/mq/lib/help/en/add_connfact.htm
 ...
-Force removing directory /export/glassfish3/glassfish/lib/appclient
-Force removing directory /export/glassfish3/glassfish/lib
-Force removing directory /export/glassfish3/glassfish
+Force removing directory /export/payara6/glassfish/lib/appclient
+Force removing directory /export/payara6/glassfish/lib
+Force removing directory /export/payara6/glassfish
 Command uninstall-node-ssh executed successfully.
 ----
 

--- a/docs/modules/ROOT/pages/Technical Documentation/Payara Server Documentation/Command Reference/uninstall-node.adoc
+++ b/docs/modules/ROOT/pages/Technical Documentation/Payara Server Documentation/Command Reference/uninstall-node.adoc
@@ -54,7 +54,7 @@ asadmin-options::
   Displays the help text for the subcommand.
 `--installdir`::
   The absolute path to the parent of the base installation directory where the Payara Server software is installed on each host, for
-  example, `/export/glassfish3/`. +
+  example, `/export/payara6/`. +
   The user that is running this subcommand must have write access to the specified directory. Otherwise, an error occurs. +
   The specified directory must contain the installation of the Payara Server software on the host. Otherwise, an error occurs. +
   The default is the parent of the base installation directory of the Payara Server software on the host where this subcommand is run.
@@ -110,21 +110,21 @@ Command uninstall-node executed successfully.
 
 This example uninstalls Payara Server software on the host `sj02.example.com`.
 
-The software is uninstalled even if a user-defined node resides on the host. The entire content of the `/export/glassfish3` directory is removed.
+The software is uninstalled even if a user-defined node resides on the host. The entire content of the `/export/payara6` directory is removed.
 
 Some lines of output are omitted from this example for readability.
 
 [source,shell]
 ----
-asadmin> uninstall-node --force --installdir /export/glassfish3 sj02.example.com
+asadmin> uninstall-node --force --installdir /export/payara6 sj02.example.com
 Successfully connected to gfuser@sj02.example.com using keyfile /home/gfuser
 /.ssh/id_rsa
-Force removing file /export/glassfish3/mq/lib/help/en/add_overrides.htm
-Force removing file /export/glassfish3/mq/lib/help/en/add_connfact.htm
+Force removing file /export/payara6/mq/lib/help/en/add_overrides.htm
+Force removing file /export/payara6/mq/lib/help/en/add_connfact.htm
 ...
-Force removing directory /export/glassfish3/glassfish/lib/appclient
-Force removing directory /export/glassfish3/glassfish/lib
-Force removing directory /export/glassfish3/glassfish
+Force removing directory /export/payara6/glassfish/lib/appclient
+Force removing directory /export/payara6/glassfish/lib
+Force removing directory /export/payara6/glassfish
 Command uninstall-node executed successfully.
 ----
 

--- a/docs/modules/ROOT/pages/Technical Documentation/Payara Server Documentation/Command Reference/update-node-config.adoc
+++ b/docs/modules/ROOT/pages/Technical Documentation/Payara Server Documentation/Command Reference/update-node-config.adoc
@@ -40,7 +40,7 @@ asadmin-options::
 `--nodehost`::
   The name of the host that the node is to represent after the node is updated.
 `--installdir`::
-  The full path to the parent of the base installation directory of the Payara Server software on the host, for example, `/export/glassfish3`.
+  The full path to the parent of the base installation directory of the Payara Server software on the host, for example, `/export/payara6`.
 `--nodedir`::
   The path to the directory that is to contain Payara Server instances that are created on the node. If a relative path is
   specified, the path is relative to the as-install directory, where as-install is the base installation directory of the Payara Server software on the host.

--- a/docs/modules/ROOT/pages/Technical Documentation/Payara Server Documentation/Command Reference/update-node-dcom.adoc
+++ b/docs/modules/ROOT/pages/Technical Documentation/Payara Server Documentation/Command Reference/update-node-dcom.adoc
@@ -43,7 +43,7 @@ asadmin-options::
 `--nodehost`::
   The name of the host that the node is to represent after the node is updated.
 `--installdir`::
-  The full path to the parent of the base installation directory of the Payara Server software on the host, for example, `/export/glassfish3/`.
+  The full path to the parent of the base installation directory of the Payara Server software on the host, for example, `/export/payara6/`.
 `--nodedir`::
   The path to the directory that is to contain Payara Server instances that are created on the node. If a relative path is specified, the path is relative to the as-install directory, where as-install is the base installation directory of the Payara Server software on the host.
 `--windowsuser`::

--- a/docs/modules/ROOT/pages/Technical Documentation/Payara Server Documentation/General Administration/domains.adoc
+++ b/docs/modules/ROOT/pages/Technical Documentation/Payara Server Documentation/General Administration/domains.adoc
@@ -647,7 +647,7 @@ Configuration location of the service:/home/gfuser/glassfish-installations
 /glassfishv3/glassfish/domains
 Manifest file location on the system:/var/svc/manifest/application
 /GlassFish/domain1_home_gfuser_glassfish-installations_glassfishv3
-_glassfish_domains/Domain-service-smf.xml.
+_payara_domains/Domain-service-smf.xml.
 You have created the service but you need to start it yourself.
 Here are the most typical Solaris commands of interest:
 * /usr/bin/svcs -a | grep domain1 // status

--- a/docs/modules/ROOT/pages/Technical Documentation/Payara Server Documentation/General Administration/domains.adoc
+++ b/docs/modules/ROOT/pages/Technical Documentation/Payara Server Documentation/General Administration/domains.adoc
@@ -593,7 +593,7 @@ Here are the most typical Linux commands of interest:
 * /etc/init.d/GlassFish_domain1 restart
 
 For your convenience this message has also been saved to this file: 
-/export/glassfish3/glassfish/domains/domain1/PlatformServices.log
+/export/payara6/glassfish/domains/domain1/PlatformServices.log
 Command create-service executed successfully.
 ----
 
@@ -998,8 +998,8 @@ Command stop-domain executed successfully.
 $ asadmin start-domain
 Waiting for domain1 to start ........................
 Successfully started the domain : domain1
-domain  Location: /export/glassfish3/glassfish/domains/domain1
-Log File: /export/glassfish3/glassfish/domains/domain1/logs/server.log
+domain  Location: /export/payara6/glassfish/domains/domain1
+Log File: /export/payara6/glassfish/domains/domain1/logs/server.log
 Admin Port: 4849
 Command start-domain executed successfully.
 ----

--- a/docs/modules/ROOT/pages/Technical Documentation/Payara Server Documentation/General Administration/rest-interface.adoc
+++ b/docs/modules/ROOT/pages/Technical Documentation/Payara Server Documentation/General Administration/rest-interface.adoc
@@ -163,7 +163,7 @@ curl -X GET -H "Accept: application/json" http://localhost:4848/management/domai
       }
     ],
     "entity":{
-      "installDir":"\/export\/glassfish3",
+      "installDir":"\/export\/payara6",
       "name":"sj01",
       "nodeDir":null,
       "nodeHost":
@@ -227,7 +227,7 @@ curl -X GET -H "Accept: application/json" http://localhost:4848/management/domai
       }
     ],
     "entity":{
-      "installDir":"\/export\/glassfish3",
+      "installDir":"\/export\/payara6",
       "name":"sj01",
       "nodeDir":null,
       "nodeHost":
@@ -775,7 +775,7 @@ This example shows the JSON representation of the resource for the node `sj01`. 
       }
     ],
     "entity":{
-      "installDir":"\/export\/glassfish3",
+      "installDir":"\/export\/payara6",
       "name":"sj01",
       "nodeDir":null,
       "nodeHost":
@@ -1012,7 +1012,7 @@ This example shows the XML representation of the resource for the node `sj01`. I
    </entry>
    <entry key="entity">
     <map>
-     <entry key="installDir" value="/export/glassfish3"/>
+     <entry key="installDir" value="/export/payara6"/>
      <entry key="name" value="sj01"/>
      <entry key="nodeDir" value=""/>
      <entry key="type" value="SSH"/>

--- a/docs/modules/ROOT/pages/Technical Documentation/Payara Server Documentation/High Availability/ssh-setup.adoc
+++ b/docs/modules/ROOT/pages/Technical Documentation/Payara Server Documentation/High Availability/ssh-setup.adoc
@@ -1141,7 +1141,7 @@ C:\Windows\system32>C:
 
 C:\Windows\system32>cd "C:\payara"
 
-C:\glassfish3>jar xvf payara_install.zip
+C:\payara6>jar xvf payara_install.zip
  inflated: bin/asadmin
  inflated: bin/asadmin.bat
  inflated: glassfish/bin/appclient

--- a/docs/modules/ROOT/pages/Technical Documentation/Payara Server Documentation/Server Configuration And Management/Asadmin Commands/Server Management Asadmin Commands.adoc
+++ b/docs/modules/ROOT/pages/Technical Documentation/Payara Server Documentation/Server Configuration And Management/Asadmin Commands/Server Management Asadmin Commands.adoc
@@ -650,7 +650,7 @@ Name of the service:application/GlassFish/domain1
 Type of the service:Domain
 Configuration location of the service:/opt/payara/glassfish/domains
 Manifest file location on the system:/var/svc/manifest/application
-/GlassFish/domain1_opt_payara_glassfish_domains/Domain-service-smf.xml.
+/GlassFish/domain1_opt_payara_payara_domains/Domain-service-smf.xml.
 You have created the service but you need to start it yourself.
 Here are the most typical Solaris commands of interest:
 * /usr/bin/svcs -a | grep domain1 // status

--- a/stashed_docs/modules/performance-tuning-guide/pages/preface.adoc
+++ b/stashed_docs/modules/performance-tuning-guide/pages/preface.adoc
@@ -242,22 +242,22 @@ In configuration files, as-install is represented as follows:
 Installations on the Oracle Solaris operating system, Linux operating
 system, and Mac OS operating system:
 
-user's-home-directory`/glassfish3/glassfish`
+user's-home-directory`/payara6/glassfish`
 
 Installations on the Windows operating system:
 
-SystemDrive`:\glassfish3\glassfish`
+SystemDrive`:\payara6\glassfish`
 
 |as-install-parent + |Represents the parent of the base installation
 directory for GlassFish Server. a|
 Installations on the Oracle Solaris operating system, Linux operating
 system, and Mac operating system:
 
-user's-home-directory`/glassfish3`
+user's-home-directory`/payara6`
 
 Installations on the Windows operating system:
 
-SystemDrive`:\glassfish3`
+SystemDrive`:\payara6`
 
 |domain-root-dir + |Represents the directory in which a domain is
 created by default. |as-install`/domains/`


### PR DESCRIPTION
Fixed several references to `glassfish3` in sample file paths across the revamped documentation.