### PR TITLE
FISH-7821 FISH-8190 Add Docker ARM64 Note

### DIFF
--- a/community/docs/modules/ROOT/pages/Technical Documentation/Payara Micro Documentation/Payara Micro Docker Image.adoc
+++ b/community/docs/modules/ROOT/pages/Technical Documentation/Payara Micro Documentation/Payara Micro Docker Image.adoc
@@ -25,6 +25,8 @@ Keep in mind the following:
 docker run -p 8080:8080 payara/micro:{page-version}
 ----
 
+Payara publishes images for AMD64 & ARM64. Your Docker client should automatically download the appropriate image for your architecture.
+
 [[jdk-version]]
 == Specifying the JDK Version
 

--- a/community/docs/modules/ROOT/pages/Technical Documentation/Payara Micro Documentation/Payara Micro Docker Image.adoc
+++ b/community/docs/modules/ROOT/pages/Technical Documentation/Payara Micro Documentation/Payara Micro Docker Image.adoc
@@ -25,7 +25,7 @@ Keep in mind the following:
 docker run -p 8080:8080 payara/micro:{page-version}
 ----
 
-Payara publishes images for AMD64 & ARM64. Your Docker client should automatically download the appropriate image for your architecture.
+AMD64 & ARM64 compatible images are provided. The Docker client should automatically download the appropriate image for your architecture.
 
 [[jdk-version]]
 == Specifying the JDK Version

--- a/community/docs/modules/ROOT/pages/Technical Documentation/Payara Server Documentation/Payara Server Docker Image.adoc
+++ b/community/docs/modules/ROOT/pages/Technical Documentation/Payara Server Documentation/Payara Server Docker Image.adoc
@@ -25,7 +25,7 @@ Keep in mind the following:
 docker run -p 8080:8080 payara/server-full:{page-version}
 ----
 
-Payara publishes images for AMD64 & ARM64. Your Docker client should automatically download the appropriate image for your architecture.
+AMD64 & ARM64 compatible images are provided. The Docker client should automatically download the appropriate image for your architecture.
 
 [[other-distributions]]
 == Other distributions

--- a/community/docs/modules/ROOT/pages/Technical Documentation/Payara Server Documentation/Payara Server Docker Image.adoc
+++ b/community/docs/modules/ROOT/pages/Technical Documentation/Payara Server Documentation/Payara Server Docker Image.adoc
@@ -25,6 +25,8 @@ Keep in mind the following:
 docker run -p 8080:8080 payara/server-full:{page-version}
 ----
 
+Payara publishes images for AMD64 & ARM64. Your Docker client should automatically download the appropriate image for your architecture.
+
 [[other-distributions]]
 == Other distributions
 

--- a/enterprise/docs/modules/ROOT/pages/Technical Documentation/Payara Micro Documentation/Payara Micro Docker Image.adoc
+++ b/enterprise/docs/modules/ROOT/pages/Technical Documentation/Payara Micro Documentation/Payara Micro Docker Image.adoc
@@ -27,6 +27,8 @@ IMPORTANT: It is recommended to specify the tag name of the Docker image that yo
 docker run -p 8080:8080 nexus.payara.fish:5000/payara/micro:{page-version}
 ----
 
+Payara publishes images for AMD64 & ARM64. Your Docker client should automatically download the appropriate image for your architecture.
+
 [[jdk-version]]
 == Specifying the JDK Version
 

--- a/enterprise/docs/modules/ROOT/pages/Technical Documentation/Payara Micro Documentation/Payara Micro Docker Image.adoc
+++ b/enterprise/docs/modules/ROOT/pages/Technical Documentation/Payara Micro Documentation/Payara Micro Docker Image.adoc
@@ -27,7 +27,7 @@ IMPORTANT: It is recommended to specify the tag name of the Docker image that yo
 docker run -p 8080:8080 nexus.payara.fish:5000/payara/micro:{page-version}
 ----
 
-Payara publishes images for AMD64 & ARM64. Your Docker client should automatically download the appropriate image for your architecture.
+AMD64 & ARM64 compatible images are provided. The Docker client should automatically download the appropriate image for your architecture.
 
 [[jdk-version]]
 == Specifying the JDK Version

--- a/enterprise/docs/modules/ROOT/pages/Technical Documentation/Payara Server Documentation/Payara Server Docker Image.adoc
+++ b/enterprise/docs/modules/ROOT/pages/Technical Documentation/Payara Server Documentation/Payara Server Docker Image.adoc
@@ -27,7 +27,7 @@ IMPORTANT: It is recommended to specify the tag of the correct Payara Enterprise
 docker run -p 8080:8080 nexus.payara.fish:5000/payara/server-full:{page-version}
 ----
 
-Payara publishes images for AMD64 & ARM64. Your Docker client should automatically download the appropriate image for your architecture.
+AMD64 & ARM64 compatible images are provided. The Docker client should automatically download the appropriate image for your architecture.
 
 [[other-distributions]]
 == Other distributions

--- a/enterprise/docs/modules/ROOT/pages/Technical Documentation/Payara Server Documentation/Payara Server Docker Image.adoc
+++ b/enterprise/docs/modules/ROOT/pages/Technical Documentation/Payara Server Documentation/Payara Server Docker Image.adoc
@@ -27,6 +27,8 @@ IMPORTANT: It is recommended to specify the tag of the correct Payara Enterprise
 docker run -p 8080:8080 nexus.payara.fish:5000/payara/server-full:{page-version}
 ----
 
+Payara publishes images for AMD64 & ARM64. Your Docker client should automatically download the appropriate image for your architecture.
+
 [[other-distributions]]
 == Other distributions
 


### PR DESCRIPTION
Adds a small note about us providing AMD64 and ARM64 images, and that Docker should sort it out for them