### PR TITLE
FISH-8603 Payara Enterprise 6.14.0 Release Notes and TCK Results

### DIFF
--- a/enterprise/docs/modules/ROOT/pages/Eclipse MicroProfile Certification/6.14.0/Overview.adoc
+++ b/enterprise/docs/modules/ROOT/pages/Eclipse MicroProfile Certification/6.14.0/Overview.adoc
@@ -1,0 +1,9 @@
+= MicroProfile 6.1 Certification Summaries
+
+Payara Server is a certified https://projects.eclipse.org/projects/technology.microprofile/releases/microprofile-6.1[MicroProfile 6.1] implementation.
+As proof of compatibility, the output of the MicroProfile TCK Test Suite tests are presented for each certified version.
+
+The following distributions of Payara 6.14.0 are certified, with results for each listed below:
+
+* xref:Eclipse MicroProfile Certification/6.14.0/Server TCK Results.adoc[Payara Server 6.14.0]
+* xref:Eclipse MicroProfile Certification/6.14.0/Server Web TCK Results.adoc[Payara Server 6.14.0 - Web profile]

--- a/enterprise/docs/modules/ROOT/pages/Eclipse MicroProfile Certification/6.14.0/Server TCK Results.adoc
+++ b/enterprise/docs/modules/ROOT/pages/Eclipse MicroProfile Certification/6.14.0/Server TCK Results.adoc
@@ -23,7 +23,6 @@ https://download.eclipse.org/microprofile/microprofile-fault-tolerance-4.0.2/mic
 https://download.eclipse.org/microprofile/microprofile-jwt-auth-2.1/microprofile-jwt-auth-spec-2.1.html[MicroProfile JWT Auth 2.1]
 https://download.eclipse.org/microprofile/microprofile-metrics-5.1.0/microprofile-metrics-spec-5.1.0.html[MicroProfile Metrics 5.1.0]
 https://download.eclipse.org/microprofile/microprofile-open-api-3.1/microprofile-openapi-spec-3.1.html[MicroProfile OpenAPI 3.1]
-https://download.eclipse.org/microprofile/microprofile-opentracing-3.0/microprofile-opentracing-spec-3.0.html[MicroProfile OpenTracing 3.0]
 https://download.eclipse.org/microprofile/microprofile-rest-client-3.0/microprofile-rest-client-spec-3.0.html[MicroProfile Rest Client 3.0]
 https://download.eclipse.org/microprofile/microprofile-telemetry-1.1/tracing/microprofile-telemetry-tracing-spec-1.1.html[MicroProfile Telemetry Tracing 1.1]
 
@@ -85,13 +84,6 @@ Number of tests skipped 0
 ### OpenTelemetry-Tracing
 ```
 Completed running 56 tests
-Number of tests failed 0
-Number of tests with errors 0
-Number of tests skipped 0
-```
-### OpenTracing
-```
-Completed running 66 tests
 Number of tests failed 0
 Number of tests with errors 0
 Number of tests skipped 0

--- a/enterprise/docs/modules/ROOT/pages/Eclipse MicroProfile Certification/6.14.0/Server TCK Results.adoc
+++ b/enterprise/docs/modules/ROOT/pages/Eclipse MicroProfile Certification/6.14.0/Server TCK Results.adoc
@@ -1,0 +1,111 @@
+[[tck-results]]
+= TCK Results
+
+As required by the https://www.eclipse.org/legal/tck.php[Eclipse Foundation Technology Compatibility Kit License], following is a summary of the TCK results for releases of MicroProfile 6.1.
+
+**Payara Server 6.14.0 Full Profile Certification Summary**
+
+- Product Name, Version and download URL (if applicable):
++
+[cols="1,2",grid=none,frame=none]
+|===
+|image:JakartaEE_Logo_compatible-color.png[]
+|
+{empty} +
+{empty} +
+https://www.payara.fish/page/payara-enterprise-downloads/[Payara Server 6.14.0]
+|===
+
+- Specification Names, Versions and download URLs:
++
+https://download.eclipse.org/microprofile/microprofile-config-3.1/microprofile-config-spec-3.1.html[MicroProfile Config 3.1]
+https://download.eclipse.org/microprofile/microprofile-fault-tolerance-4.0.2/microprofile-fault-tolerance-spec-4.0.2.html[MicroProfile Fault Tolerance 4.0.2]
+https://download.eclipse.org/microprofile/microprofile-jwt-auth-2.1/microprofile-jwt-auth-spec-2.1.html[MicroProfile JWT Auth 2.1]
+https://download.eclipse.org/microprofile/microprofile-metrics-5.1.0/microprofile-metrics-spec-5.1.0.html[MicroProfile Metrics 5.1.0]
+https://download.eclipse.org/microprofile/microprofile-open-api-3.1/microprofile-openapi-spec-3.1.html[MicroProfile OpenAPI 3.1]
+https://download.eclipse.org/microprofile/microprofile-opentracing-3.0/microprofile-opentracing-spec-3.0.html[MicroProfile OpenTracing 3.0]
+https://download.eclipse.org/microprofile/microprofile-rest-client-3.0/microprofile-rest-client-spec-3.0.html[MicroProfile Rest Client 3.0]
+https://download.eclipse.org/microprofile/microprofile-telemetry-1.1/tracing/microprofile-telemetry-tracing-spec-1.1.html[MicroProfile Telemetry Tracing 1.1]
+
+- Public URL of TCK Results Summary:
++
+https://docs.payara.fish/enterprise/docs/6.14.0/Eclipse%20MicroProfile%20Certification/6.14.0/Server%20TCK%20Results.html
+
+
+- Java runtime used to run the implementation:
++
+Zulu JDK Runtime Environment (version 11.0.14.1)
+- Summary of the information for the certification environment:
++
+Jenkins AWS EC2 Linux Cloud, Ubuntu 20.04 LTS +
+
+== Test results
+### Config
+```
+Completed running 374 tests
+Number of tests failed 0
+Number of tests with errors 0
+Number of tests skipped 0
+```
+### Fault-Tolerance
+```
+Completed running 442 tests
+Number of tests failed 0
+Number of tests with errors 0
+Number of tests skipped 0
+```
+### Health
+```
+Completed running 28 tests
+Number of tests failed 0
+Number of tests with errors 0
+Number of tests skipped 0
+```
+### JWT-Auth
+```
+Completed running 206 tests
+Number of tests failed 0
+Number of tests with errors 0
+Number of tests skipped 0
+```
+### Metrics
+```
+Completed running 185 tests
+Number of tests failed 0
+Number of tests with errors 0
+Number of tests skipped 0
+```
+### OpenAPI
+```
+Completed running 273 tests
+Number of tests failed 0
+Number of tests with errors 0
+Number of tests skipped 0
+```
+### OpenTelemetry-Tracing
+```
+Completed running 56 tests
+Number of tests failed 0
+Number of tests with errors 0
+Number of tests skipped 0
+```
+### OpenTracing
+```
+Completed running 66 tests
+Number of tests failed 0
+Number of tests with errors 0
+Number of tests skipped 0
+```
+### Rest-Client
+```
+Completed running 220 tests
+Number of tests failed 0
+Number of tests with errors 0
+Number of tests skipped 13
+
+Apache HTTP Client
+Completed running 5 tests
+Number of tests failed 0
+Number of tests with errors 0
+Number of tests skipped 0
+```

--- a/enterprise/docs/modules/ROOT/pages/Eclipse MicroProfile Certification/6.14.0/Server Web TCK Results.adoc
+++ b/enterprise/docs/modules/ROOT/pages/Eclipse MicroProfile Certification/6.14.0/Server Web TCK Results.adoc
@@ -23,7 +23,6 @@ https://download.eclipse.org/microprofile/microprofile-fault-tolerance-4.0.2/mic
 https://download.eclipse.org/microprofile/microprofile-jwt-auth-2.1/microprofile-jwt-auth-spec-2.1.html[MicroProfile JWT Auth 2.1]
 https://download.eclipse.org/microprofile/microprofile-metrics-5.1.0/microprofile-metrics-spec-5.1.0.html[MicroProfile Metrics 5.1.0]
 https://download.eclipse.org/microprofile/microprofile-open-api-3.1/microprofile-openapi-spec-3.1.html[MicroProfile OpenAPI 3.1]
-https://download.eclipse.org/microprofile/microprofile-opentracing-3.0/microprofile-opentracing-spec-3.0.html[MicroProfile OpenTracing 3.0]
 https://download.eclipse.org/microprofile/microprofile-rest-client-3.0/microprofile-rest-client-spec-3.0.html[MicroProfile Rest Client 3.0]
 https://download.eclipse.org/microprofile/microprofile-telemetry-1.1/tracing/microprofile-telemetry-tracing-spec-1.1.html[MicroProfile Telemetry Tracing 1.1]
 
@@ -85,13 +84,6 @@ Number of tests skipped 0
 ### OpenTelemetry-Tracing
 ```
 Completed running 56 tests
-Number of tests failed 0
-Number of tests with errors 0
-Number of tests skipped 0
-```
-### OpenTracing
-```
-Completed running 66 tests
 Number of tests failed 0
 Number of tests with errors 0
 Number of tests skipped 0

--- a/enterprise/docs/modules/ROOT/pages/Eclipse MicroProfile Certification/6.14.0/Server Web TCK Results.adoc
+++ b/enterprise/docs/modules/ROOT/pages/Eclipse MicroProfile Certification/6.14.0/Server Web TCK Results.adoc
@@ -1,0 +1,111 @@
+[[tck-results]]
+= TCK Results
+
+As required by the https://www.eclipse.org/legal/tck.php[Eclipse Foundation Technology Compatibility Kit License], following is a summary of the TCK results for releases of MicroProfile 6.1.
+
+**Payara Server 6.14.0 Web Profile Certification Summary**
+
+- Product Name, Version and download URL (if applicable):
++
+[cols="1,2",grid=none,frame=none]
+|===
+|image:JakartaEE_Logo_compatible-color.png[]
+|
+{empty} +
+{empty} +
+https://www.payara.fish/page/payara-enterprise-downloads/[Payara Server 6.14.0 (Web Profile)]
+|===
+
+- Specification Names, Versions and download URLs:
++
+https://download.eclipse.org/microprofile/microprofile-config-3.1/microprofile-config-spec-3.1.html[MicroProfile Config 3.1]
+https://download.eclipse.org/microprofile/microprofile-fault-tolerance-4.0.2/microprofile-fault-tolerance-spec-4.0.2.html[MicroProfile Fault Tolerance 4.0.2]
+https://download.eclipse.org/microprofile/microprofile-jwt-auth-2.1/microprofile-jwt-auth-spec-2.1.html[MicroProfile JWT Auth 2.1]
+https://download.eclipse.org/microprofile/microprofile-metrics-5.1.0/microprofile-metrics-spec-5.1.0.html[MicroProfile Metrics 5.1.0]
+https://download.eclipse.org/microprofile/microprofile-open-api-3.1/microprofile-openapi-spec-3.1.html[MicroProfile OpenAPI 3.1]
+https://download.eclipse.org/microprofile/microprofile-opentracing-3.0/microprofile-opentracing-spec-3.0.html[MicroProfile OpenTracing 3.0]
+https://download.eclipse.org/microprofile/microprofile-rest-client-3.0/microprofile-rest-client-spec-3.0.html[MicroProfile Rest Client 3.0]
+https://download.eclipse.org/microprofile/microprofile-telemetry-1.1/tracing/microprofile-telemetry-tracing-spec-1.1.html[MicroProfile Telemetry Tracing 1.1]
+
+- Public URL of TCK Results Summary:
++
+https://docs.payara.fish/enterprise/docs/6.14.0/Eclipse%20MicroProfile%20Certification/6.14.0/Server%20Web%20TCK%20Results.html
+
+
+- Java runtime used to run the implementation:
++
+Zulu JDK Runtime Environment (version 11.0.14.1)
+- Summary of the information for the certification environment:
++
+Jenkins AWS EC2 Linux Cloud, Ubuntu 20.04 LTS +
+
+== Test results
+### Config
+```
+Completed running 374 tests
+Number of tests failed 0
+Number of tests with errors 0
+Number of tests skipped 0
+```
+### Fault-Tolerance
+```
+Completed running 442 tests
+Number of tests failed 0
+Number of tests with errors 0
+Number of tests skipped 0
+```
+### Health
+```
+Completed running 28 tests
+Number of tests failed 0
+Number of tests with errors 0
+Number of tests skipped 0
+```
+### JWT-Auth
+```
+Completed running 206 tests
+Number of tests failed 0
+Number of tests with errors 0
+Number of tests skipped 0
+```
+### Metrics
+```
+Completed running 185 tests
+Number of tests failed 0
+Number of tests with errors 0
+Number of tests skipped 0
+```
+### OpenAPI
+```
+Completed running 273 tests
+Number of tests failed 0
+Number of tests with errors 0
+Number of tests skipped 0
+```
+### OpenTelemetry-Tracing
+```
+Completed running 56 tests
+Number of tests failed 0
+Number of tests with errors 0
+Number of tests skipped 0
+```
+### OpenTracing
+```
+Completed running 66 tests
+Number of tests failed 0
+Number of tests with errors 0
+Number of tests skipped 0
+```
+### Rest-Client
+```
+Completed running 220 tests
+Number of tests failed 0
+Number of tests with errors 0
+Number of tests skipped 13
+
+Apache HTTP Client
+Completed running 5 tests
+Number of tests failed 0
+Number of tests with errors 0
+Number of tests skipped 0
+```

--- a/enterprise/docs/modules/ROOT/pages/Jakarta EE Certification/6.14.0/6.14.0 (Web Profile) Core TCK Results.adoc
+++ b/enterprise/docs/modules/ROOT/pages/Jakarta EE Certification/6.14.0/6.14.0 (Web Profile) Core TCK Results.adoc
@@ -1,0 +1,160 @@
+[[tck-results]]
+= TCK Results
+
+As required by the https://www.eclipse.org/legal/tck.php[Eclipse Foundation Technology Compatibility Kit License], following is a summary of the TCK results for Payara Server releases for Jakarta EE Core Profile 10.
+
+[[payara-server-web-results]]
+== Payara Server 6.14.0 (Web Profile) Jakarta EE 10 Core Profile Certification Summary
+
+- Product Name, Version and download URL (if applicable):
++
+[cols="1,2",grid=none,frame=none]
+|===
+|image:JakartaEE_Logo_compatible-color.png[]
+|
+{empty} +
+{empty} +
+https://www.payara.fish/page/payara-enterprise-downloads/[Payara Server 6.14.0 (Web Profile)]
+|===
+
+- Specification Name, Version and download URL:
++
+https://jakarta.ee/specifications/coreprofile/10/[Jakarta EE Core Profile 10]
+- TCK Version, digital SHA-256 fingerprint and download URL:
++
+https://download.eclipse.org/jakartaee/coreprofile/10.0/jakarta-core-profile-tck-10.0.0.zip[Jakarta EE Core Profile TCK 10.0.0.zip]
+, SHA-256: `702a84e3c6532fb0aad6a37443bf5e7fadbfb7cf0071271f3a1fdd10cab1229c`
+
+- Public URL of TCK Results Summary:
++
+https://docs.payara.fish/enterprise/docs/6.14.0/Jakarta%20EE%20Certification/6.14.0/6.14.0%20(Web%20Profile)%20Core%20TCK%20Results.html[6.14.0 Core TCK Results]
+
+- Any Additional Specification Certification Requirements:
+
+** Jakarta Concurrency 3.0.2 TCK
++
+See test results in section `concurrency`. +
+Download URL & SHA-256:
+https://download.eclipse.org/jakartaee/concurrency/3.0/concurrency-tck-3.0.2.zip[concurrency-tck-3.0.2.zip],
+SHA-256:  `22728d729f620d6a85ae903e7d1184e0a7508a4328491b785f1b4f3d7215ca93`
+
+** Jakarta Contexts and Dependency Injection 4.0.6 TCK
++
+See test results in section `cdi` and `cdi-lang-model`. +
+Download URL & SHA-256:
+https://download.eclipse.org/ee4j/cdi/4.0/cdi-tck-4.0.6-dist.zip[cdi-tck-4.0.6-dist.zip],
+SHA-256:  `5da8beecb66937d2272fec95fa37a01c5b9b459fcccd5f8f5f12193e6bfd9710`
+
+** Jakarta Dependency Injection 2.0.2 TCK
++
+See test results in section `di`. +
+Download URL & SHA-256:
+https://download.eclipse.org/ee4j/cdi/inject/2.0/jakarta.inject-tck-2.0.2-bin.zip[jakarta.inject-tck-2.0.2-bin.zip],
+SHA-256: `23bce4317ca061c3de648566cdf65c74b57e1264d6891f366567955d6b834972`
+
+** Jakarta RESTful Web Services 3.1.2 TCK
++
+See test results in section `jaxrs`. +
+Download URL & SHA-256:
+https://download.eclipse.org/jakartaee/restful-ws/3.1/jakarta-restful-ws-tck-3.1.2.zip[jakarta-restful-ws-tck-3.1.2.zip],
+SHA-256: `d854850faf1ab09279f515fef052de5e57afbc591e72d071337e08f0edf41d25`
+
+** Jakarta JSON Binding 3.0.0 TCK
++
+See test results in section `jsonb`. +
+Download URL & SHA-256:
+https://download.eclipse.org/jakartaee/jsonb/3.0/jakarta-jsonb-tck-3.0.0.zip[jakarta-jsonb-tck-3.0.0.zip],
+SHA-256: `954fd9a3a67059ddeabe5f51462a6a3b542c94fc798094dd8c312a6a28ef2d0b`
+
+** Jakarta JSON Processing 2.1.1 TCK
++
+See test results in section `jsonp`. +
+Download URL & SHA-256:
+https://download.eclipse.org/jakartaee/jsonp/2.1/jakarta-jsonp-tck-2.1.1.zip[jakarta-jsonp-tck-2.1.1.zip],
+SHA-256: `949f203de84deffa8c7892b555918e42f1dd220ccb7b6800741ea58af62737c1`
+
+- Java runtime used to run the implementation:
++
+`OpenJDK Runtime Environment Zulu11.54+25-CA (build 11.0.14.1+1-LTS)`
+
+
+- Summary of the information for the certification environment:
++
+Apache Derby, Linux, Ubuntu 20.04 LTS +
+
+=== Test Results
+
+### cdi
+
+```
+    [INFO]  [mvn.test] [INFO] Results:
+    [INFO]  [mvn.test] [INFO]
+    [INFO]  [mvn.test] [INFO] Tests run: 725, Failures: 0, Errors: 0, Skipped: 0
+```
+
+
+### cdi-lang-model
+
+```
+    Results :
+
+    Tests run: 1, Failures: 0, Errors: 0, Skipped: 0
+```
+
+### concurrency
+
+```
+    [INFO] Results:
+    [INFO]
+    [INFO] Tests run: 148, Failures: 0, Errors: 0, Skipped: 0
+```
+
+### core
+
+```
+    [INFO] Results:
+    [INFO]
+    [INFO] Tests run: 13, Failures: 0, Errors: 0, Skipped: 0
+```
+
+### di
+
+```
+    Completed running 50 tests
+    Number of tests failed 0
+    Number of tests with errors 0
+    Number of tests skipped 0
+```
+
+### jaxrs
+
+```
+    [INFO] Results:
+    [INFO]
+    [WARNING] Tests run: 2660, Failures: 0, Errors: 0, Skipped: 59
+
+    [INFO] Results:
+    [INFO]
+    [INFO] Tests run: 7, Failures: 0, Errors: 0, Skipped: 0
+```
+
+### jsonb
+
+```
+    [INFO] Results:
+    [INFO]
+    [WARNING] Tests run: 294, Failures: 0, Errors: 0, Skipped: 5
+```
+
+### jsonp
+
+```
+    [INFO] Results:
+    [INFO]
+    [INFO] Tests run: 179, Failures: 0, Errors: 0, Skipped: 0
+
+    Pluggability Tests:
+    [INFO] Results:
+    [INFO]
+    [INFO] Tests run: 18, Failures: 0, Errors: 0, Skipped: 0
+```

--- a/enterprise/docs/modules/ROOT/pages/Jakarta EE Certification/6.14.0/6.14.0 (Web Profile) Web TCK Results.adoc
+++ b/enterprise/docs/modules/ROOT/pages/Jakarta EE Certification/6.14.0/6.14.0 (Web Profile) Web TCK Results.adoc
@@ -186,7 +186,7 @@ Apache Derby, Linux, Ubuntu 20.04 LTS +
 
 ```
     [junit] Testsuite: org.jboss.weld.atinject.tck.AtInjectTCK
-    [junit] Tests run: 50, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.08 sec
+    [junit] Tests run: 50, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.079 sec
 ```
 
 ### ejb30/lite/appexception

--- a/enterprise/docs/modules/ROOT/pages/Jakarta EE Certification/6.14.0/6.14.0 (Web Profile) Web TCK Results.adoc
+++ b/enterprise/docs/modules/ROOT/pages/Jakarta EE Certification/6.14.0/6.14.0 (Web Profile) Web TCK Results.adoc
@@ -1,0 +1,520 @@
+[[tck-results]]
+= TCK Results
+
+As required by the https://www.eclipse.org/legal/tck.php[Eclipse Foundation Technology Compatibility Kit License], following is a summary of the TCK results for Payara Server releases for Jakarta EE Platform 10.
+
+[[payara-server-web-results]]
+== Payara Server (Web Profile) 6.14.0 Jakarta EE 10 Web Profile Certification Summary
+
+- Product Name, Version and download URL (if applicable):
++
+[cols="1,2",grid=none,frame=none]
+|===
+|image:JakartaEE_Logo_compatible-color.png[]
+|
+{empty} +
+{empty} +
+https://www.payara.fish/page/payara-enterprise-downloads/[Payara Server 6.14.0 (Web Profile)]
+|===
+
+- Specification Name, Version and download URL:
++
+https://jakarta.ee/specifications/webprofile/10/[Jakarta EE Web Profile 10]
+- TCK Version, digital SHA-256 fingerprint and download URL:
++
+https://download.eclipse.org/jakartaee/platform/10/jakarta-jakartaeetck-10.0.0.zip[Jakarta EE Platform TCK 10.0.0.zip]
+, SHA-256: `7874244f69ed9c72f4d4b5a8c48b21d39c56f4b877b1d4d735247a7f08215a5e`
+
+- Public URL of TCK Results Summary:
++
+https://docs.payara.fish/enterprise/docs/6.14.0/Jakarta%20EE%20Certification/6.14.0/6.14.0%20Web%20TCK%20Results.html[6.14.0 Web TCK Results]
+
+- Any Additional Specification Certification Requirements:
+
+** Jakarta Authentication 3.0.1
++
+See test results in section `authentication`. +
+Download URL & SHA-256:
+https://download.eclipse.org/jakartaee/authentication/3.0/jakarta-authentication-tck-3.0.1.zip[jakarta-authentication-tck-3.0.1.zip],
+SHA-256:  `8b916f1b4aed828337bd88b34bb39b133f04611c2dfe71541c2ec5d2dd22cd54`
+
+** Jakarta Bean Validation 3.0.1
++
+See test results in section `beanvalidation`. +
+Download URL & SHA-256:
+https://download.eclipse.org/jakartaee/bean-validation/3.0/beanvalidation-tck-dist-3.0.1.zip[beanvalidation-tck-dist-3.0.1.zip],
+SHA-256:  `9da36d2d6e2eb8d413f886f15711820008419d210ce4c51af04f96e1ffd583b3`
+
+** Jakarta Concurrency 3.0.2 TCK
++
+See test results in section `concurrency`. +
+Download URL & SHA-256:
+https://download.eclipse.org/jakartaee/concurrency/3.0/concurrency-tck-3.0.2.zip[concurrency-tck-3.0.2.zip],
+SHA-256:  `22728d729f620d6a85ae903e7d1184e0a7508a4328491b785f1b4f3d7215ca93`
+
+** Jakarta Contexts and Dependency Injection 4.0.6 TCK
++
+See test results in section `cdi` and `cdi-lang-model`. +
+Download URL & SHA-256:
+https://download.eclipse.org/ee4j/cdi/4.0/cdi-tck-4.0.6-dist.zip[cdi-tck-4.0.6-dist.zip],
+SHA-256:  `5da8beecb66937d2272fec95fa37a01c5b9b459fcccd5f8f5f12193e6bfd9710`
+
+** Jakarta Debugging Support for Other Languages 2.0.0 TCK
++
+See test results in section `debugging`. +
+Download URL & SHA-256:
+https://download.eclipse.org/jakartaee/debugging/2.0/jakarta-debugging-tck-2.0.0.zip[jakarta-debugging-tck-2.0.0.zip],
+SHA-256: `71999815418799837dc6f3d0dc40c3dcc4144cd90c7cdfd06aa69270483d78bc`
+
+** Jakarta Dependency Injection 2.0.2 TCK
++
+See test results in section `di`. +
+Download URL & SHA-256:
+https://download.eclipse.org/ee4j/cdi/inject/2.0/jakarta.inject-tck-2.0.2-bin.zip[jakarta.inject-tck-2.0.2-bin.zip],
+SHA-256: `23bce4317ca061c3de648566cdf65c74b57e1264d6891f366567955d6b834972`
+
+** Jakarta Faces 4.0.1 TCK
++
+See test results in section `jsf`. +
+Download URL & SHA-256:
+https://download.eclipse.org/jakartaee/faces/4.0/jakarta-faces-tck-4.0.1.zip[jakarta-faces-tck-4.0.1.zip],
+SHA-256: `117fdbf8aee14ee162cc913ae055621f7e067b0be4dd14c4591be76b90a0dde5`
+
+** Jakarta JSON Binding 3.0.0 TCK
++
+See test results in section `jsonb`. +
+Download URL & SHA-256:
+https://download.eclipse.org/jakartaee/jsonb/3.0/jakarta-jsonb-tck-3.0.0.zip[jakarta-jsonb-tck-3.0.0.zip],
+SHA-256: `954fd9a3a67059ddeabe5f51462a6a3b542c94fc798094dd8c312a6a28ef2d0b`
+
+** Jakarta JSON Processing 2.1.1 TCK
++
+See test results in section `jsonp`. +
+Download URL & SHA-256:
+https://download.eclipse.org/jakartaee/jsonp/2.1/jakarta-jsonp-tck-2.1.1.zip[jakarta-jsonp-tck-2.1.1.zip],
+SHA-256: `949f203de84deffa8c7892b555918e42f1dd220ccb7b6800741ea58af62737c1`
+
+** Jakarta RESTful Web Services 3.1.2 TCK
++
+See test results in section `jaxrs`. +
+Download URL & SHA-256:
+https://download.eclipse.org/jakartaee/restful-ws/3.1/jakarta-restful-ws-tck-3.1.2.zip[jakarta-restful-ws-tck-3.1.2.zip],
+SHA-256: `d854850faf1ab09279f515fef052de5e57afbc591e72d071337e08f0edf41d25`
+
+** Jakarta Security 3.0.0 TCK
++
+See test results in section `security`. +
+Download URL & SHA-256:
+https://download.eclipse.org/jakartaee/security/3.0/jakarta-security-tck-3.0.0.zip[jakarta-security-tck-3.0.0.zip],
+SHA-256: `696776046dfeaed74266a5d1c4dac7fea5437b6f51743b7fe10962dde755ff8f`
+
+- Java runtime used to run the implementation:
++
+`OpenJDK Runtime Environment Zulu11.54+25-CA (build 11.0.14.1+1-LTS)`
+
+
+- Summary of the information for the certification environment:
++
+Apache Derby, Linux, Ubuntu 20.04 LTS +
+
+=== Test Results
+
+### authentication
+
+```
+   Old TCK Module:
+   [INFO]      [exec] [javatest.batch] Completed running 68 tests.
+   [INFO]      [exec] [javatest.batch] Number of Tests Passed      = 68
+   [INFO]      [exec] [javatest.batch] Number of Tests Failed      = 0
+   [INFO]      [exec] [javatest.batch] Number of Tests with Errors = 0
+
+   Test Modules:
+   ########################################################
+   Tests run: 70, Failures: 0, Errors: 0, Skipped: 0
+   ########################################################
+```
+
+### beanvalidation
+
+```
+   [mvn.test] Results :
+   [mvn.test]
+   [mvn.test] Tests run: 1045, Failures: 0, Errors: 0, Skipped: 0
+```
+
+### cdi
+
+```
+    [INFO]  [mvn.test] [INFO] Results:
+    [INFO]  [mvn.test] [INFO]
+    [INFO]  [mvn.test] [INFO] Tests run: 1697, Failures: 0, Errors: 0, Skipped: 0
+```
+
+### cdi-lang-model
+
+```
+    Results :
+    Tests run: 1, Failures: 0, Errors: 0, Skipped: 0
+```
+
+#### concurrency
+
+```
+    [INFO] Results:
+    [INFO]
+    [INFO] Tests run: 148, Failures: 0, Errors: 0, Skipped: 0
+```
+
+### connector
+
+```
+   [runcts] OUT => [javatest.batch] Completed running 252 tests.
+   [runcts] OUT => [javatest.batch] Number of Tests Passed      = 252
+   [runcts] OUT => [javatest.batch] Number of Tests Failed      = 0
+   [runcts] OUT => [javatest.batch] Number of Tests with Errors = 0
+```
+
+### debugging
+
+```
+   + echo '<testsuite id="1" name="debugging-tck" tests="1" failures="0" errors="0" disabled="0" skipped="0">'
+   + echo '<testcase name="VerifySMAP" classname="VerifySMAP" time="0" status="Passed"><system-out></system-out></testcase>'
+```
+
+
+### di
+
+```
+    [junit] Testsuite: org.jboss.weld.atinject.tck.AtInjectTCK
+    [junit] Tests run: 50, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.08 sec
+```
+
+### ejb30/lite/appexception
+
+```
+   [runcts] OUT => [javatest.batch] Completed running 365 tests.
+   [runcts] OUT => [javatest.batch] Number of Tests Passed      = 365
+   [runcts] OUT => [javatest.batch] Number of Tests Failed      = 0
+   [runcts] OUT => [javatest.batch] Number of Tests with Errors = 0
+```
+
+### ejb30/lite/async
+
+```
+   [runcts] OUT => [javatest.batch] Completed running 300 tests.
+   [runcts] OUT => [javatest.batch] Number of Tests Passed      = 300
+   [runcts] OUT => [javatest.batch] Number of Tests Failed      = 0
+   [runcts] OUT => [javatest.batch] Number of Tests with Errors = 0
+```
+
+### ejb30/lite/basic
+
+```
+   [runcts] OUT => [javatest.batch] Completed running 105 tests.
+   [runcts] OUT => [javatest.batch] Number of Tests Passed      = 105
+   [runcts] OUT => [javatest.batch] Number of Tests Failed      = 0
+   [runcts] OUT => [javatest.batch] Number of Tests with Errors = 0
+```
+
+### ejb30/lite/ejbcontext
+
+```
+   [runcts] OUT => [javatest.batch] Completed running 50 tests.
+   [runcts] OUT => [javatest.batch] Number of Tests Passed      = 50
+   [runcts] OUT => [javatest.batch] Number of Tests Failed      = 0
+   [runcts] OUT => [javatest.batch] Number of Tests with Errors = 0
+```
+
+### ejb30/lite/enventry
+
+```
+   [runcts] OUT => [javatest.batch] Completed running 30 tests.
+   [runcts] OUT => [javatest.batch] Number of Tests Passed      = 30
+   [runcts] OUT => [javatest.batch] Number of Tests Failed      = 0
+   [runcts] OUT => [javatest.batch] Number of Tests with Errors = 0
+```
+
+### ejb30/lite/interceptor
+
+```
+   [runcts] OUT => [javatest.batch] Completed running 175 tests.
+   [runcts] OUT => [javatest.batch] Number of Tests Passed      = 175
+   [runcts] OUT => [javatest.batch] Number of Tests Failed      = 0
+   [runcts] OUT => [javatest.batch] Number of Tests with Errors = 0
+```
+
+### ejb30/lite/lookup
+
+```
+   [runcts] OUT => [javatest.batch] Completed running 30 tests.
+   [runcts] OUT => [javatest.batch] Number of Tests Passed      = 30
+   [runcts] OUT => [javatest.batch] Number of Tests Failed      = 0
+   [runcts] OUT => [javatest.batch] Number of Tests with Errors = 0
+```
+
+### ejb30/lite/naming
+
+```
+   [runcts] OUT => [javatest.batch] Completed running 54 tests.
+   [runcts] OUT => [javatest.batch] Number of Tests Passed      = 54
+   [runcts] OUT => [javatest.batch] Number of Tests Failed      = 0
+   [runcts] OUT => [javatest.batch] Number of Tests with Errors = 0
+```
+
+### ejb30/lite/nointerface
+
+```
+   [runcts] OUT => [javatest.batch] Completed running 60 tests.
+   [runcts] OUT => [javatest.batch] Number of Tests Passed      = 60
+   [runcts] OUT => [javatest.batch] Number of Tests Failed      = 0
+   [runcts] OUT => [javatest.batch] Number of Tests with Errors = 0
+```
+
+### ejb30/lite/packaging
+
+```
+   [runcts] OUT => [javatest.batch] Completed running 203 tests.
+   [runcts] OUT => [javatest.batch] Number of Tests Passed      = 203
+   [runcts] OUT => [javatest.batch] Number of Tests Failed      = 0
+   [runcts] OUT => [javatest.batch] Number of Tests with Errors = 0
+```
+
+### ejb30/lite/singleton
+
+```
+   [runcts] OUT => [javatest.batch] Completed running 230 tests.
+   [runcts] OUT => [javatest.batch] Number of Tests Passed      = 230
+   [runcts] OUT => [javatest.batch] Number of Tests Failed      = 0
+   [runcts] OUT => [javatest.batch] Number of Tests with Errors = 0
+```
+
+### ejb30/lite/stateful
+
+```
+   [runcts] OUT => [javatest.batch] Completed running 124 tests.
+   [runcts] OUT => [javatest.batch] Number of Tests Passed      = 124
+   [runcts] OUT => [javatest.batch] Number of Tests Failed      = 0
+   [runcts] OUT => [javatest.batch] Number of Tests with Errors = 0
+```
+
+### ejb30/lite/tx
+
+```
+   [runcts] OUT => [javatest.batch] Completed running 358 tests.
+   [runcts] OUT => [javatest.batch] Number of Tests Passed      = 358
+   [runcts] OUT => [javatest.batch] Number of Tests Failed      = 0
+   [runcts] OUT => [javatest.batch] Number of Tests with Errors = 0
+```
+
+### ejb30/lite/view
+
+```
+   [runcts] OUT => [javatest.batch] Completed running 95 tests.
+   [runcts] OUT => [javatest.batch] Number of Tests Passed      = 95
+   [runcts] OUT => [javatest.batch] Number of Tests Failed      = 0
+   [runcts] OUT => [javatest.batch] Number of Tests with Errors = 0
+```
+
+### ejb30/lite/xmloverride
+
+```
+   [runcts] OUT => [javatest.batch] Completed running 30 tests.
+   [runcts] OUT => [javatest.batch] Number of Tests Passed      = 30
+   [runcts] OUT => [javatest.batch] Number of Tests Failed      = 0
+   [runcts] OUT => [javatest.batch] Number of Tests with Errors = 0
+```
+
+### ejb32
+```
+   [runcts] OUT => [javatest.batch] Completed running 537 tests.
+   [runcts] OUT => [javatest.batch] Number of Tests Passed      = 537
+   [runcts] OUT => [javatest.batch] Number of Tests Failed      = 0
+   [runcts] OUT => [javatest.batch] Number of Tests with Errors = 0
+```
+
+### el
+
+```
+   [runcts] OUT => [javatest.batch] Completed running 695 tests.
+   [runcts] OUT => [javatest.batch] Number of Tests Passed      = 695
+   [runcts] OUT => [javatest.batch] Number of Tests Failed      = 0
+   [runcts] OUT => [javatest.batch] Number of Tests with Errors = 0
+```
+
+### jaxrs
+
+```
+   From standalone runner:
+   [INFO] Results:
+   [INFO]
+   [WARNING] Tests run: 2660, Failures: 0, Errors: 0, Skipped: 59
+
+   From standalone runner - SE Tests:
+   [INFO] Results:
+   [INFO]
+   [INFO] Tests run: 7, Failures: 0, Errors: 0, Skipped: 0
+```
+
+### jdbc
+
+```
+   [runcts] OUT => [javatest.batch] Completed running 2462 tests.
+   [runcts] OUT => [javatest.batch] Number of Tests Passed      = 2462
+   [runcts] OUT => [javatest.batch] Number of Tests Failed      = 0
+   [runcts] OUT => [javatest.batch] Number of Tests with Errors = 0
+```
+
+### jpa
+
+```
+   [runcts] OUT => [javatest.batch] Completed running 1912 tests.
+   [runcts] OUT => [javatest.batch] Number of Tests Passed      = 1912
+   [runcts] OUT => [javatest.batch] Number of Tests Failed      = 0
+   [runcts] OUT => [javatest.batch] Number of Tests with Errors = 0
+```
+
+### jsf
+
+```
+   Test Modules:
+   Tests run: 260, 5 skipped
+
+   Old Faces TCK:
+   [INFO]      [exec] [javatest.batch] Completed running 5400 tests.
+   [INFO]      [exec] [javatest.batch] Number of Tests Passed      = 5400
+   [INFO]      [exec] [javatest.batch] Number of Tests Failed      = 0
+   [INFO]      [exec] [javatest.batch] Number of Tests with Errors = 0
+
+   Signature Test:
+   [INFO] Results:
+   [INFO]
+   [INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0
+```
+
+### jsonb
+
+```
+   From Jakarta EE 10 TCK zip:
+   [runcts] OUT => [javatest.batch] Completed running 10 tests.
+   [runcts] OUT => [javatest.batch] Number of Tests Passed      = 10
+   [runcts] OUT => [javatest.batch] Number of Tests Failed      = 0
+   [runcts] OUT => [javatest.batch] Number of Tests with Errors = 0
+
+   From standalone runner:
+   [INFO] Results:
+   [INFO]
+   [WARNING] Tests run: 294, Failures: 0, Errors: 0, Skipped: 5
+```
+
+### jsonp
+
+```
+   From Jakarta EE 10 TCK zip:
+   [runcts] OUT => [javatest.batch] Completed running 38 tests.
+   [runcts] OUT => [javatest.batch] Number of Tests Passed      = 38
+   [runcts] OUT => [javatest.batch] Number of Tests Failed      = 0
+   [runcts] OUT => [javatest.batch] Number of Tests with Errors = 0
+
+   From standalone runner:
+   [INFO] Results:
+   [INFO]
+   [INFO] Tests run: 179, Failures: 0, Errors: 0, Skipped: 0
+   Pluggability:
+   [INFO] Results:
+   [INFO]
+   [INFO] Tests run: 18, Failures: 0, Errors: 0, Skipped: 0
+```
+
+### jsp
+
+```
+   From Jakarta EE 10 TCK zip:
+   [runcts] OUT => [javatest.batch] Completed running 725 tests.
+   [runcts] OUT => [javatest.batch] Number of Tests Passed      = 725
+   [runcts] OUT => [javatest.batch] Number of Tests Failed      = 0
+   [runcts] OUT => [javatest.batch] Number of Tests with Errors = 0
+
+   From standalone runner:
+   [INFO]      [exec] [javatest.batch] Completed running 708 tests.
+   [INFO]      [exec] [javatest.batch] Number of Tests Passed      = 708
+   [INFO]      [exec] [javatest.batch] Number of Tests Failed      = 0
+   [INFO]      [exec] [javatest.batch] Number of Tests with Errors = 0
+```
+
+### jstl
+
+```
+   [runcts] OUT => [javatest.batch] Completed running 541 tests.
+   [runcts] OUT => [javatest.batch] Number of Tests Passed      = 541
+   [runcts] OUT => [javatest.batch] Number of Tests Failed      = 0
+   [runcts] OUT => [javatest.batch] Number of Tests with Errors = 0
+```
+
+### jta
+
+```
+   [runcts] OUT => [javatest.batch] Completed running 100 tests.
+   [runcts] OUT => [javatest.batch] Number of Tests Passed      = 100
+   [runcts] OUT => [javatest.batch] Number of Tests Failed      = 0
+   [runcts] OUT => [javatest.batch] Number of Tests with Errors = 0
+```
+
+### samples
+
+```
+   [runcts] OUT => [javatest.batch] Completed running 5 tests.
+   [runcts] OUT => [javatest.batch] Number of Tests Passed      = 5
+   [runcts] OUT => [javatest.batch] Number of Tests Failed      = 0
+   [runcts] OUT => [javatest.batch] Number of Tests with Errors = 0
+```
+
+### security
+
+```
+   Test Modules:
+   117 tests passed.
+
+   Old Security TCK:
+   [INFO]      [exec] [javatest.batch] Completed running 84 tests.
+   [INFO]      [exec] [javatest.batch] Number of Tests Passed      = 84
+   [INFO]      [exec] [javatest.batch] Number of Tests Failed      = 0
+   [INFO]      [exec] [javatest.batch] Number of Tests with Errors = 0
+```
+
+### servlet
+
+```
+   [runcts] OUT => [javatest.batch] Completed running 1647 tests.
+   [runcts] OUT => [javatest.batch] Number of Tests Passed      = 1647
+   [runcts] OUT => [javatest.batch] Number of Tests Failed      = 0
+   [runcts] OUT => [javatest.batch] Number of Tests with Errors = 0
+```
+
+### signaturetest/javaee
+
+```
+   [runcts] OUT => [javatest.batch] Completed running 2 tests.
+   [runcts] OUT => [javatest.batch] Number of Tests Passed      = 2
+   [runcts] OUT => [javatest.batch] Number of Tests Failed      = 0
+   [runcts] OUT => [javatest.batch] Number of Tests with Errors = 0
+```
+
+### tags
+
+```
+   [INFO]      [exec] [javatest.batch]
+   [INFO]      [exec] [javatest.batch] Completed running 541 tests.
+   [INFO]      [exec] [javatest.batch] Number of Tests Passed      = 541
+   [INFO]      [exec] [javatest.batch] Number of Tests Failed      = 0
+   [INFO]      [exec] [javatest.batch] Number of Tests with Errors = 0
+   [INFO]      [exec] [javatest.batch]
+```
+
+### websocket
+
+```
+   [runcts] OUT => [javatest.batch] Completed running 748 tests.
+   [runcts] OUT => [javatest.batch] Number of Tests Passed      = 748
+   [runcts] OUT => [javatest.batch] Number of Tests Failed      = 0
+   [runcts] OUT => [javatest.batch] Number of Tests with Errors = 0
+```

--- a/enterprise/docs/modules/ROOT/pages/Jakarta EE Certification/6.14.0/6.14.0 Core TCK Results.adoc
+++ b/enterprise/docs/modules/ROOT/pages/Jakarta EE Certification/6.14.0/6.14.0 Core TCK Results.adoc
@@ -1,0 +1,160 @@
+[[tck-results]]
+= TCK Results
+
+As required by the https://www.eclipse.org/legal/tck.php[Eclipse Foundation Technology Compatibility Kit License], following is a summary of the TCK results for Payara Server releases for Jakarta EE Core Profile 10.
+
+[[payara-server-results]]
+== Payara Server 6.14.0 Jakarta EE 10 Core Profile Certification Summary
+
+- Product Name, Version and download URL (if applicable):
++
+[cols="1,2",grid=none,frame=none]
+|===
+|image:JakartaEE_Logo_compatible-color.png[]
+|
+{empty} +
+{empty} +
+https://www.payara.fish/page/payara-enterprise-downloads/[Payara Server 6.14.0]
+|===
+
+- Specification Name, Version and download URL:
++
+https://jakarta.ee/specifications/coreprofile/10/[Jakarta EE Core Profile 10]
+- TCK Version, digital SHA-256 fingerprint and download URL:
++
+https://download.eclipse.org/jakartaee/coreprofile/10.0/jakarta-core-profile-tck-10.0.0.zip[Jakarta EE Core Profile TCK 10.0.0.zip]
+, SHA-256: `702a84e3c6532fb0aad6a37443bf5e7fadbfb7cf0071271f3a1fdd10cab1229c`
+
+- Public URL of TCK Results Summary:
++
+https://docs.payara.fish/enterprise/docs/6.14.0/Jakarta%20EE%20Certification/6.14.0/6.14.0%20Core%20TCK%20Results.html[6.14.0 Core TCK Results]
+
+- Any Additional Specification Certification Requirements:
+
+** Jakarta Concurrency 3.0.2 TCK
++
+See test results in section `concurrency`. +
+Download URL & SHA-256:
+https://download.eclipse.org/jakartaee/concurrency/3.0/concurrency-tck-3.0.2.zip[concurrency-tck-3.0.2.zip],
+SHA-256:  `22728d729f620d6a85ae903e7d1184e0a7508a4328491b785f1b4f3d7215ca93`
+
+** Jakarta Contexts and Dependency Injection 4.0.6 TCK
++
+See test results in section `cdi` and `cdi-lang-model`. +
+Download URL & SHA-256:
+https://download.eclipse.org/ee4j/cdi/4.0/cdi-tck-4.0.6-dist.zip[cdi-tck-4.0.6-dist.zip],
+SHA-256:  `5da8beecb66937d2272fec95fa37a01c5b9b459fcccd5f8f5f12193e6bfd9710`
+
+** Jakarta Dependency Injection 2.0.2 TCK
++
+See test results in section `di`. +
+Download URL & SHA-256:
+https://download.eclipse.org/ee4j/cdi/inject/2.0/jakarta.inject-tck-2.0.2-bin.zip[jakarta.inject-tck-2.0.2-bin.zip],
+SHA-256: `23bce4317ca061c3de648566cdf65c74b57e1264d6891f366567955d6b834972`
+
+** Jakarta RESTful Web Services 3.1.2 TCK
++
+See test results in section `jaxrs`. +
+Download URL & SHA-256:
+https://download.eclipse.org/jakartaee/restful-ws/3.1/jakarta-restful-ws-tck-3.1.2.zip[jakarta-restful-ws-tck-3.1.2.zip],
+SHA-256: `d854850faf1ab09279f515fef052de5e57afbc591e72d071337e08f0edf41d25`
+
+** Jakarta JSON Binding 3.0.0 TCK
++
+See test results in section `jsonb`. +
+Download URL & SHA-256:
+https://download.eclipse.org/jakartaee/jsonb/3.0/jakarta-jsonb-tck-3.0.0.zip[jakarta-jsonb-tck-3.0.0.zip],
+SHA-256: `954fd9a3a67059ddeabe5f51462a6a3b542c94fc798094dd8c312a6a28ef2d0b`
+
+** Jakarta JSON Processing 2.1.1 TCK
++
+See test results in section `jsonp`. +
+Download URL & SHA-256:
+https://download.eclipse.org/jakartaee/jsonp/2.1/jakarta-jsonp-tck-2.1.1.zip[jakarta-jsonp-tck-2.1.1.zip],
+SHA-256: `949f203de84deffa8c7892b555918e42f1dd220ccb7b6800741ea58af62737c1`
+
+- Java runtime used to run the implementation:
++
+`OpenJDK Runtime Environment Zulu11.54+25-CA (build 11.0.14.1+1-LTS)`
+
+
+- Summary of the information for the certification environment:
++
+Apache Derby, Linux, Ubuntu 20.04 LTS +
+
+=== Test Results
+
+### cdi
+
+```
+    [INFO]  [mvn.test] [INFO] Results:
+    [INFO]  [mvn.test] [INFO]
+    [INFO]  [mvn.test] [INFO] Tests run: 725, Failures: 0, Errors: 0, Skipped: 0
+```
+
+
+### cdi-lang-model
+
+```
+    Results :
+
+    Tests run: 1, Failures: 0, Errors: 0, Skipped: 0
+```
+
+### concurrency
+
+```
+    [INFO] Results:
+    [INFO]
+    [INFO] Tests run: 197, Failures: 0, Errors: 0, Skipped: 0
+```
+
+### core
+
+```
+    [INFO] Results:
+    [INFO]
+    [INFO] Tests run: 13, Failures: 0, Errors: 0, Skipped: 0
+```
+
+### di
+
+```
+    Completed running 50 tests
+    Number of tests failed 0
+    Number of tests with errors 0
+    Number of tests skipped 0
+```
+
+### jaxrs
+
+```
+    [INFO] Results:
+    [INFO]
+    [WARNING] Tests run: 2660, Failures: 0, Errors: 0, Skipped: 59
+
+    [INFO] Results:
+    [INFO]
+    [INFO] Tests run: 7, Failures: 0, Errors: 0, Skipped: 0
+```
+
+### jsonb
+
+```
+    [INFO] Results:
+    [INFO]
+    [WARNING] Tests run: 294, Failures: 0, Errors: 0, Skipped: 5
+```
+
+### jsonp
+
+```
+    [INFO] Results:
+    [INFO]
+    [INFO] Tests run: 179, Failures: 0, Errors: 0, Skipped: 0
+
+    Pluggability Tests:
+    [INFO] Results:
+    [INFO]
+    [INFO] Tests run: 18, Failures: 0, Errors: 0, Skipped: 0
+```

--- a/enterprise/docs/modules/ROOT/pages/Jakarta EE Certification/6.14.0/6.14.0 Platform TCK Results.adoc
+++ b/enterprise/docs/modules/ROOT/pages/Jakarta EE Certification/6.14.0/6.14.0 Platform TCK Results.adoc
@@ -267,7 +267,7 @@ Interoperability tests carried out against Eclipse Glassfish 7.0 (Nightly)
 ### di
 
 ```
-    [junit] Tests run: 50, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.086 sec
+    [junit] Tests run: 50, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.083 sec
 ```
 
 ### debugging
@@ -281,11 +281,11 @@ Interoperability tests carried out against Eclipse Glassfish 7.0 (Nightly)
 
 ```
    [runcts] OUT => [javatest.batch] Completed running 1793 tests.
-   [runcts] OUT => [javatest.batch] Number of Tests Passed      = 1605
-   [runcts] OUT => [javatest.batch] Number of Tests Failed      = 188
+   [runcts] OUT => [javatest.batch] Number of Tests Passed      = 1628
+   [runcts] OUT => [javatest.batch] Number of Tests Failed      = 165
    [runcts] OUT => [javatest.batch] Number of Tests with Errors = 0
-   [runcts] OUT => [javatest.batch] Completed running 188 tests.
-   [runcts] OUT => [javatest.batch] Number of Tests Passed      = 188
+   [runcts] OUT => [javatest.batch] Completed running 165 tests.
+   [runcts] OUT => [javatest.batch] Number of Tests Passed      = 165
    [runcts] OUT => [javatest.batch] Number of Tests Failed      = 0
    [runcts] OUT => [javatest.batch] Number of Tests with Errors = 0
 ```

--- a/enterprise/docs/modules/ROOT/pages/Jakarta EE Certification/6.14.0/6.14.0 Platform TCK Results.adoc
+++ b/enterprise/docs/modules/ROOT/pages/Jakarta EE Certification/6.14.0/6.14.0 Platform TCK Results.adoc
@@ -1,0 +1,910 @@
+[[tck-results]]
+= TCK Results
+
+As required by the https://www.eclipse.org/legal/tck.php[Eclipse Foundation Technology Compatibility Kit License], following is a summary of the TCK results for Payara Server releases for Jakarta EE Platform 10.
+
+[[payara-server-results]]
+== Payara Server 6.14.0 Jakarta EE 10 Platform Certification Summary
+
+As required by the
+https://www.eclipse.org/legal/tck.php[Eclipse Foundation Technology Compatibility Kit License],
+following is a summary of the TCK results for Payara Server releases for Jakarta EE Platform 10.
+
+- Product Name, Version and download URL (if applicable):
++
+[cols="1,2",grid=none,frame=none]
+|===
+|image:JakartaEE_Logo_compatible-color.png[]
+|
+{empty} +
+{empty} +
+https://www.payara.fish/page/payara-enterprise-downloads/[Payara Server 6.14.0]
+|===
+
+- Specification Name, Version and download URL:
++
+https://jakarta.ee/specifications/platform/10/[Jakarta EE Platform 10]
++
+https://download.eclipse.org/jakartaee/platform/10/jakarta-jakartaeetck-10.0.0.zip[Jakarta EE Platform TCK 10.0.0.zip]
+, SHA-256: `7874244f69ed9c72f4d4b5a8c48b21d39c56f4b877b1d4d735247a7f08215a5e`
+
+- Public URL of TCK Results Summary:
++
+https://docs.payara.fish/enterprise/docs/6.14.0/Jakarta%20EE%20Certification/6.14.0/6.14.0%20Platform%20TCK%20Results.html[6.14.0 Platform TCK Results]
+
+** Jakarta Activation 2.1.0
++
+See test results in section `activation`. +
+Download URL & SHA-256:
+https://download.eclipse.org/jakartaee/activation/2.1/jakarta-activation-tck-2.1.0.zip[activation-tck-2.1.0.zip],
+SHA-256:  `6c4aad27e45761dd9f3e0f8506f37edea41f42401465db750689145718b27a0b`
+
+** Jakarta Authentication 3.0.1
++
+See test results in section `authentication`. +
+Download URL & SHA-256:
+https://download.eclipse.org/jakartaee/authentication/3.0/jakarta-authentication-tck-3.0.1.zip[jakarta-authentication-tck-3.0.1.zip],
+SHA-256:  `8b916f1b4aed828337bd88b34bb39b133f04611c2dfe71541c2ec5d2dd22cd54`
+
+** Jakarta Batch 2.1.1 TCK
++
+See test results in section `batch`. +
+Download URL & SHA-256:
+https://download.eclipse.org/jakartaee/batch/2.1/jakarta.batch.official.tck-2.1.1.zip[jakarta.batch.official.tck-2.1.1.zip],
+SHA-256: `0dd8ca0f35cc696ea86d0dffaa1301cf2786806832ea1b2a491d528eaa57b3b7`
+
+** Jakarta Bean Validation 3.0.1
++
+See test results in section `beanvalidation`. +
+Download URL & SHA-256:
+https://download.eclipse.org/jakartaee/bean-validation/3.0/beanvalidation-tck-dist-3.0.1.zip[beanvalidation-tck-dist-3.0.1.zip],
+SHA-256:  `9da36d2d6e2eb8d413f886f15711820008419d210ce4c51af04f96e1ffd583b3`
+
+** Jakarta Concurrency 3.0.2 TCK
++
+See test results in section `concurrency`. +
+Download URL & SHA-256:
+https://download.eclipse.org/jakartaee/concurrency/3.0/concurrency-tck-3.0.2.zip[concurrency-tck-3.0.2.zip],
+SHA-256:  `22728d729f620d6a85ae903e7d1184e0a7508a4328491b785f1b4f3d7215ca93`
+
+** Jakarta Contexts and Dependency Injection 4.0.6 TCK
++
+See test results in sections `cdi` and `cdi-lang-model`. +
+Download URL & SHA-256:
+https://download.eclipse.org/ee4j/cdi/4.0/cdi-tck-4.0.6-dist.zip[cdi-tck-4.0.6-dist.zip],
+SHA-256:  `5da8beecb66937d2272fec95fa37a01c5b9b459fcccd5f8f5f12193e6bfd9710`
+
+** Jakarta Debugging Support for Other Languages 2.0.0 TCK
++
+See test results in section `debugging`. +
+Download URL & SHA-256:
+https://download.eclipse.org/jakartaee/debugging/2.0/jakarta-debugging-tck-2.0.0.zip[jakarta-debugging-tck-2.0.0.zip],
+SHA-256: `71999815418799837dc6f3d0dc40c3dcc4144cd90c7cdfd06aa69270483d78bc`
+
+** Jakarta Dependency Injection 2.0.2 TCK
++
+See test results in section `di`. +
+Download URL & SHA-256:
+https://download.eclipse.org/ee4j/cdi/inject/2.0/jakarta.inject-tck-2.0.2-bin.zip[jakarta.inject-tck-2.0.2-bin.zip],
+SHA-256: `23bce4317ca061c3de648566cdf65c74b57e1264d6891f366567955d6b834972`
+
+** Jakarta JSON Binding 3.0.0 TCK
++
+See test results in section `jsonb`. +
+Download URL & SHA-256:
+https://download.eclipse.org/jakartaee/jsonb/3.0/jakarta-jsonb-tck-3.0.0.zip[jakarta-jsonb-tck-3.0.0.zip],
+SHA-256: `954fd9a3a67059ddeabe5f51462a6a3b542c94fc798094dd8c312a6a28ef2d0b`
+
+** Jakarta JSON Processing 2.1.1 TCK
++
+See test results in section `jsonp`. +
+Download URL & SHA-256:
+https://download.eclipse.org/jakartaee/jsonp/2.1/jakarta-jsonp-tck-2.1.1.zip[jakarta-jsonp-tck-2.1.1.zip],
+SHA-256: `949f203de84deffa8c7892b555918e42f1dd220ccb7b6800741ea58af62737c1`
+
+** Jakarta Faces 4.0.1 TCK
++
+See test results in section `jsf`. +
+Download URL & SHA-256:
+https://download.eclipse.org/jakartaee/faces/4.0/jakarta-faces-tck-4.0.1.zip[jakarta-faces-tck-4.0.1.zip],
+SHA-256: `117fdbf8aee14ee162cc913ae055621f7e067b0be4dd14c4591be76b90a0dde5`
+
+** Jakarta Mail 2.1.0 TCK
++
+See test results in section `javamail`. +
+Download URL & SHA-256:
+https://download.eclipse.org/jakartaee/mail/2.1/jakarta-mail-tck-2.1.0.zip[jakarta-mail-tck-2.1.0.zip],
+SHA-256: `6f02a92e0a5ef60260e65f95938cc566da2f93a3d269c3b321da0d787a3448a5`
+
+** Jakarta RESTful Web Services 3.1.2 TCK
++
+See test results in section `jaxrs`. +
+Download URL & SHA-256:
+https://download.eclipse.org/jakartaee/restful-ws/3.1/jakarta-restful-ws-tck-3.1.2.zip[jakarta-restful-ws-tck-3.1.2.zip],
+SHA-256: `d854850faf1ab09279f515fef052de5e57afbc591e72d071337e08f0edf41d25`
+
+** Jakarta Security 3.0.0 TCK
++
+See test results in section `security`. +
+Download URL & SHA-256:
+https://download.eclipse.org/jakartaee/security/3.0/jakarta-security-tck-3.0.0.zip[jakarta-security-tck-3.0.0.zip],
+SHA-256: `696776046dfeaed74266a5d1c4dac7fea5437b6f51743b7fe10962dde755ff8f`
+
+** Jakarta XML Binding 4.0.0 TCK
++
+See test results in section `jaxb`. +
+Download URL & SHA-256:
+https://download.eclipse.org/jakartaee/xml-binding/4.0/jakarta-xml-binding-tck-4.0.1.zip[jakarta-xml-binding-tck-4.0.1.zip],
+SHA-256: `146be8dc429eb6271a940bf7652f4e11421be702357dbca2cbd93c09c53fac2e`
+
+- Java runtime used to run the implementation:
++
+`OpenJDK Runtime Environment Zulu11.54+25-CA (build 11.0.14.1+1-LTS)`
+
+
+- Summary of the information for the certification environment:
++
+Apache Derby, Linux, Ubuntu 20.04 LTS +
+Interoperability tests carried out against Eclipse Glassfish 7.0 (Nightly)
+
+== Test results
+
+### activation
+
+```
+   [javatest.batch] Completed running 91 tests.
+   [javatest.batch] Number of Tests Passed      = 91
+   [javatest.batch] Number of Tests Failed      = 0
+   [javatest.batch] Number of Tests with Errors = 0
+   [javatest.batch] Number of Tests Not Run     = 0
+   Pluggability:
+   [javatest.batch] Completed running 2 tests.
+   [javatest.batch] Number of Tests Passed      = 2
+   [javatest.batch] Number of Tests Failed      = 0
+   [javatest.batch] Number of Tests with Errors = 0
+   [javatest.batch] Number of Tests Not Run     = 0
+```
+
+### appclient
+
+```
+   [runcts] OUT => [javatest.batch] Completed running 50 tests.
+   [runcts] OUT => [javatest.batch] Number of Tests Passed      = 50
+   [runcts] OUT => [javatest.batch] Number of Tests Failed      = 0
+   [runcts] OUT => [javatest.batch] Number of Tests with Errors = 0
+```
+
+### assembly
+
+```
+   [runcts] OUT => [javatest.batch] Completed running 30 tests.
+   [runcts] OUT => [javatest.batch] Number of Tests Passed      = 30
+   [runcts] OUT => [javatest.batch] Number of Tests Failed      = 0
+   [runcts] OUT => [javatest.batch] Number of Tests with Errors = 0
+```
+
+### authentication
+
+```
+   Old TCK Module:
+   [INFO]      [exec] [javatest.batch] Completed running 68 tests.
+   [INFO]      [exec] [javatest.batch] Number of Tests Passed      = 68
+   [INFO]      [exec] [javatest.batch] Number of Tests Failed      = 0
+   [INFO]      [exec] [javatest.batch] Number of Tests with Errors = 0
+
+   Test Modules:
+   ########################################################
+   Tests run: 70, Failures: 0, Errors: 0, Skipped: 0
+   ########################################################
+```
+
+### authorization
+
+```
+   [INFO]      [exec] [javatest.batch] Completed running 34 tests.
+   [INFO]      [exec] [javatest.batch] Number of Tests Passed      = 34
+   [INFO]      [exec] [javatest.batch] Number of Tests Failed      = 0
+   [INFO]      [exec] [javatest.batch] Number of Tests with Errors = 0
+```
+
+### batch
+
+```
+   Jakarta Batch API TCK Runner for Payara
+   [INFO] Results:
+   [INFO]
+   [WARNING] Tests run: 386, Failures: 0, Errors: 0, Skipped: 12
+```
+
+### beanvalidation
+
+```
+   [mvn.test] Results :
+   [mvn.test]
+   [mvn.test] Tests run: 1045, Failures: 0, Errors: 0, Skipped: 0
+```
+
+### cdi
+
+```
+    [INFO]  [mvn.test] [INFO] Results:
+    [INFO]  [mvn.test] [INFO]
+    [INFO]  [mvn.test] [INFO] Tests run: 1831, Failures: 0, Errors: 0, Skipped: 0
+```
+
+### cdi-lang-model
+
+```
+    Results :
+    Tests run: 1, Failures: 0, Errors: 0, Skipped: 0
+```
+
+### concurrency
+
+```
+    [INFO] Results:
+    [INFO]
+    [INFO] Tests run: 197, Failures: 0, Errors: 0, Skipped: 0
+```
+
+### connector
+
+```
+   [runcts] OUT => [javatest.batch] Completed running 477 tests.
+   [runcts] OUT => [javatest.batch] Number of Tests Passed      = 477
+   [runcts] OUT => [javatest.batch] Number of Tests Failed      = 0
+   [runcts] OUT => [javatest.batch] Number of Tests with Errors = 0
+```
+
+### core
+
+```
+    [INFO] Results:
+    [INFO]
+    [INFO] Tests run: 13, Failures: 0, Errors: 0, Skipped: 0
+```
+
+### di
+
+```
+    [junit] Tests run: 50, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.086 sec
+```
+
+### debugging
+
+```
+   + echo '<testsuite id="1" name="debugging-tck" tests="1" failures="0" errors="0" disabled="0" skipped="0">'
+   + echo '<testcase name="VerifySMAP" classname="VerifySMAP" time="0" status="Passed"><system-out></system-out></testcase>'
+```
+
+### ejb
+
+```
+   [runcts] OUT => [javatest.batch] Completed running 1793 tests.
+   [runcts] OUT => [javatest.batch] Number of Tests Passed      = 1605
+   [runcts] OUT => [javatest.batch] Number of Tests Failed      = 188
+   [runcts] OUT => [javatest.batch] Number of Tests with Errors = 0
+   [runcts] OUT => [javatest.batch] Completed running 188 tests.
+   [runcts] OUT => [javatest.batch] Number of Tests Passed      = 188
+   [runcts] OUT => [javatest.batch] Number of Tests Failed      = 0
+   [runcts] OUT => [javatest.batch] Number of Tests with Errors = 0
+```
+
+### ejb30/assembly
+
+```
+   [runcts] OUT => [javatest.batch] Completed running 51 tests.
+   [runcts] OUT => [javatest.batch] Number of Tests Passed      = 51
+   [runcts] OUT => [javatest.batch] Number of Tests Failed      = 0
+   [runcts] OUT => [javatest.batch] Number of Tests with Errors = 0
+```
+
+### ejb30/bb
+
+```
+   [runcts] OUT => [javatest.batch] Completed running 1193 tests.
+   [runcts] OUT => [javatest.batch] Number of Tests Passed      = 1158
+   [runcts] OUT => [javatest.batch] Number of Tests Failed      = 35
+   [runcts] OUT => [javatest.batch] Number of Tests with Errors = 0
+   [runcts] OUT => [javatest.batch] Completed running 35 tests.
+   [runcts] OUT => [javatest.batch] Number of Tests Passed      = 35
+   [runcts] OUT => [javatest.batch] Number of Tests Failed      = 0
+   [runcts] OUT => [javatest.batch] Number of Tests with Errors = 0
+```
+
+### ejb30/lite/appexception
+
+```
+   [runcts] OUT => [javatest.batch] Completed running 365 tests.
+   [runcts] OUT => [javatest.batch] Number of Tests Passed      = 365
+   [runcts] OUT => [javatest.batch] Number of Tests Failed      = 0
+   [runcts] OUT => [javatest.batch] Number of Tests with Errors = 0
+```
+
+### ejb30/lite/async
+
+```
+   [runcts] OUT => [javatest.batch] Completed running 300 tests.
+   [runcts] OUT => [javatest.batch] Number of Tests Passed      = 300
+   [runcts] OUT => [javatest.batch] Number of Tests Failed      = 0
+   [runcts] OUT => [javatest.batch] Number of Tests with Errors = 0
+```
+
+### ejb30/lite/basic
+
+```
+   [runcts] OUT => [javatest.batch] Completed running 105 tests.
+   [runcts] OUT => [javatest.batch] Number of Tests Passed      = 105
+   [runcts] OUT => [javatest.batch] Number of Tests Failed      = 0
+   [runcts] OUT => [javatest.batch] Number of Tests with Errors = 0
+```
+
+### ejb30/lite/ejbcontext
+
+```
+   [runcts] OUT => [javatest.batch] Completed running 50 tests.
+   [runcts] OUT => [javatest.batch] Number of Tests Passed      = 50
+   [runcts] OUT => [javatest.batch] Number of Tests Failed      = 0
+   [runcts] OUT => [javatest.batch] Number of Tests with Errors = 0
+```
+
+### ejb30/lite/enventry
+
+```
+   [runcts] OUT => [javatest.batch] Completed running 30 tests.
+   [runcts] OUT => [javatest.batch] Number of Tests Passed      = 30
+   [runcts] OUT => [javatest.batch] Number of Tests Failed      = 0
+   [runcts] OUT => [javatest.batch] Number of Tests with Errors = 0
+```
+
+### ejb30/lite/interceptor
+
+```
+   [runcts] OUT => [javatest.batch] Completed running 175 tests.
+   [runcts] OUT => [javatest.batch] Number of Tests Passed      = 175
+   [runcts] OUT => [javatest.batch] Number of Tests Failed      = 0
+   [runcts] OUT => [javatest.batch] Number of Tests with Errors = 0
+```
+
+### ejb30/lite/lookup
+
+```
+   [runcts] OUT => [javatest.batch] Completed running 30 tests.
+   [runcts] OUT => [javatest.batch] Number of Tests Passed      = 30
+   [runcts] OUT => [javatest.batch] Number of Tests Failed      = 0
+   [runcts] OUT => [javatest.batch] Number of Tests with Errors = 0
+```
+
+### ejb30/lite/naming
+
+```
+   [runcts] OUT => [javatest.batch] Completed running 54 tests.
+   [runcts] OUT => [javatest.batch] Number of Tests Passed      = 54
+   [runcts] OUT => [javatest.batch] Number of Tests Failed      = 0
+   [runcts] OUT => [javatest.batch] Number of Tests with Errors = 0
+```
+
+### ejb30/lite/nointerface
+
+```
+   [runcts] OUT => [javatest.batch] Completed running 60 tests.
+   [runcts] OUT => [javatest.batch] Number of Tests Passed      = 60
+   [runcts] OUT => [javatest.batch] Number of Tests Failed      = 0
+   [runcts] OUT => [javatest.batch] Number of Tests with Errors = 0
+```
+
+### ejb30/lite/packaging
+
+```
+   [runcts] OUT => [javatest.batch] Completed running 211 tests.
+   [runcts] OUT => [javatest.batch] Number of Tests Passed      = 211
+   [runcts] OUT => [javatest.batch] Number of Tests Failed      = 0
+   [runcts] OUT => [javatest.batch] Number of Tests with Errors = 0
+```
+
+### ejb30/lite/singleton
+
+```
+   [runcts] OUT => [javatest.batch] Completed running 230 tests.
+   [runcts] OUT => [javatest.batch] Number of Tests Passed      = 230
+   [runcts] OUT => [javatest.batch] Number of Tests Failed      = 0
+   [runcts] OUT => [javatest.batch] Number of Tests with Errors = 0
+```
+
+### ejb30/lite/stateful
+
+```
+   [runcts] OUT => [javatest.batch] Completed running 124 tests.
+   [runcts] OUT => [javatest.batch] Number of Tests Passed      = 124
+   [runcts] OUT => [javatest.batch] Number of Tests Failed      = 0
+   [runcts] OUT => [javatest.batch] Number of Tests with Errors = 0
+```
+
+### ejb30/lite/tx
+
+```
+   [runcts] OUT => [javatest.batch] Completed running 358 tests.
+   [runcts] OUT => [javatest.batch] Number of Tests Passed      = 358
+   [runcts] OUT => [javatest.batch] Number of Tests Failed      = 0
+   [runcts] OUT => [javatest.batch] Number of Tests with Errors = 0
+```
+
+### ejb30/lite/view
+
+```
+   [runcts] OUT => [javatest.batch] Completed running 95 tests.
+   [runcts] OUT => [javatest.batch] Number of Tests Passed      = 95
+   [runcts] OUT => [javatest.batch] Number of Tests Failed      = 0
+   [runcts] OUT => [javatest.batch] Number of Tests with Errors = 0
+```
+
+### ejb30/lite/xmloverride
+
+```
+   [runcts] OUT => [javatest.batch] Completed running 30 tests.
+   [runcts] OUT => [javatest.batch] Number of Tests Passed      = 30
+   [runcts] OUT => [javatest.batch] Number of Tests Failed      = 0
+   [runcts] OUT => [javatest.batch] Number of Tests with Errors = 0
+```
+
+### ejb30/misc
+
+```
+   [runcts] OUT => [javatest.batch] Completed running 100 tests.
+   [runcts] OUT => [javatest.batch] Number of Tests Passed      = 100
+   [runcts] OUT => [javatest.batch] Number of Tests Failed      = 0
+   [runcts] OUT => [javatest.batch] Number of Tests with Errors = 0
+```
+
+### ejb30/sec
+
+```
+   [runcts] OUT => [javatest.batch] Completed running 99 tests.
+   [runcts] OUT => [javatest.batch] Number of Tests Passed      = 99
+   [runcts] OUT => [javatest.batch] Number of Tests Failed      = 0
+   [runcts] OUT => [javatest.batch] Number of Tests with Errors = 0
+```
+
+### ejb30/timer
+
+```
+   [runcts] OUT => [javatest.batch] Completed running 178 tests.
+   [runcts] OUT => [javatest.batch] Number of Tests Passed      = 178
+   [runcts] OUT => [javatest.batch] Number of Tests Failed      = 0
+   [runcts] OUT => [javatest.batch] Number of Tests with Errors = 0
+```
+
+### ejb30/webservice
+
+```
+   [runcts] OUT => [javatest.batch] Completed running 3 tests.
+   [runcts] OUT => [javatest.batch] Number of Tests Passed      = 3
+   [runcts] OUT => [javatest.batch] Number of Tests Failed      = 0
+   [runcts] OUT => [javatest.batch] Number of Tests with Errors = 0
+```
+
+### ejb30/zombie
+
+```
+   [runcts] OUT => [javatest.batch] Completed running 1 tests.
+   [runcts] OUT => [javatest.batch] Number of Tests Passed      = 1
+   [runcts] OUT => [javatest.batch] Number of Tests Failed      = 0
+   [runcts] OUT => [javatest.batch] Number of Tests with Errors = 0
+```
+
+### ejb32
+
+```
+   [runcts] OUT => [javatest.batch] Completed running 825 tests.
+   [runcts] OUT => [javatest.batch] Number of Tests Passed      = 825
+   [runcts] OUT => [javatest.batch] Number of Tests Failed      = 0
+   [runcts] OUT => [javatest.batch] Number of Tests with Errors = 0
+```
+
+### el
+
+```
+   [runcts] OUT => [javatest.batch] Completed running 695 tests.
+   [runcts] OUT => [javatest.batch] Number of Tests Passed      = 695
+   [runcts] OUT => [javatest.batch] Number of Tests Failed      = 0
+   [runcts] OUT => [javatest.batch] Number of Tests with Errors = 0
+```
+
+### integration
+
+```
+   [runcts] OUT => [javatest.batch] Completed running 18 tests.
+   [runcts] OUT => [javatest.batch] Number of Tests Passed      = 18
+   [runcts] OUT => [javatest.batch] Number of Tests Failed      = 0
+   [runcts] OUT => [javatest.batch] Number of Tests with Errors = 0
+```
+
+### jacc
+
+```
+   [runcts] OUT => [javatest.batch] Completed running 40 tests.
+   [runcts] OUT => [javatest.batch] Number of Tests Passed      = 40
+   [runcts] OUT => [javatest.batch] Number of Tests Failed      = 0
+   [runcts] OUT => [javatest.batch] Number of Tests with Errors = 0
+```
+
+### javaee
+
+```
+   [runcts] OUT => [javatest.batch] Completed running 24 tests.
+   [runcts] OUT => [javatest.batch] Number of Tests Passed      = 24
+   [runcts] OUT => [javatest.batch] Number of Tests Failed      = 0
+   [runcts] OUT => [javatest.batch] Number of Tests with Errors = 0
+```
+
+### javamail
+
+```
+   From Jakarta EE 10 TCK zip:
+   [runcts] OUT => [javatest.batch] Completed running 112 tests.
+   [runcts] OUT => [javatest.batch] Number of Tests Passed      = 112
+   [runcts] OUT => [javatest.batch] Number of Tests Failed      = 0
+   [runcts] OUT => [javatest.batch] Number of Tests with Errors = 0
+
+   From standalone runner:
+   [javatest.batch] Completed running 321 tests.
+   [javatest.batch] Number of Tests Passed      = 321
+   [javatest.batch] Number of Tests Failed      = 0
+   [javatest.batch] Number of Tests with Errors = 0
+   [javatest.batch] Number of Tests Not Run     = 0
+
+   From standalone runner - pluggability:
+   [javatest.batch] Number of Tests Passed      = 1
+   [javatest.batch] Number of Tests Failed      = 0
+   [javatest.batch] Number of Tests with Errors = 0
+   [javatest.batch] Number of Tests Not Run     = 0
+```
+
+### jaxb
+
+```
+Test results: passed: 24,626; failed: 0
+```
+
+### jaxrs
+
+```
+   From Jakarta EE 10 TCK zip:
+   [runcts] OUT => [javatest.batch] Completed running 138 tests.
+   [runcts] OUT => [javatest.batch] Number of Tests Passed      = 138
+   [runcts] OUT => [javatest.batch] Number of Tests Failed      = 0
+   [runcts] OUT => [javatest.batch] Number of Tests with Errors = 0
+
+   From standalone runner:
+   [INFO] Results:
+   [INFO]
+   [WARNING] Tests run: 2660, Failures: 0, Errors: 0, Skipped: 59
+
+   From standalone runner - SE Tests:
+   [INFO] Results:
+   [INFO]
+   [INFO] Tests run: 7, Failures: 0, Errors: 0, Skipped: 0
+```
+
+### jdbc_appclient
+
+```
+   [runcts] OUT => [javatest.batch] Completed running 1231 tests.
+   [runcts] OUT => [javatest.batch] Number of Tests Passed      = 1231
+   [runcts] OUT => [javatest.batch] Number of Tests Failed      = 0
+   [runcts] OUT => [javatest.batch] Number of Tests with Errors = 0
+```
+
+### jdbc_ejb
+
+```
+   [runcts] OUT => [javatest.batch] Completed running 1231 tests.
+   [runcts] OUT => [javatest.batch] Number of Tests Passed      = 1231
+   [runcts] OUT => [javatest.batch] Number of Tests Failed      = 0
+   [runcts] OUT => [javatest.batch] Number of Tests with Errors = 0
+```
+
+### jdbc_jsp
+
+```
+   [runcts] OUT => [javatest.batch] Completed running 1231 tests.
+   [runcts] OUT => [javatest.batch] Number of Tests Passed      = 1231
+   [runcts] OUT => [javatest.batch] Number of Tests Failed      = 0
+   [runcts] OUT => [javatest.batch] Number of Tests with Errors = 0
+```
+
+### jdbc_servlet
+
+```
+   [runcts] OUT => [javatest.batch] Completed running 1231 tests.
+   [runcts] OUT => [javatest.batch] Number of Tests Passed      = 1231
+   [runcts] OUT => [javatest.batch] Number of Tests Failed      = 0
+   [runcts] OUT => [javatest.batch] Number of Tests with Errors = 0
+```
+
+### jms/core
+
+```
+   [runcts] OUT => [javatest.batch] Completed running 2379 tests.
+   [runcts] OUT => [javatest.batch] Number of Tests Passed      = 2379
+   [runcts] OUT => [javatest.batch] Number of Tests Failed      = 0
+   [runcts] OUT => [javatest.batch] Number of Tests with Errors = 0
+```
+
+### jms/core20
+
+```
+   [runcts] OUT => [javatest.batch] Completed running 852 tests.
+   [runcts] OUT => [javatest.batch] Number of Tests Passed      = 852
+   [runcts] OUT => [javatest.batch] Number of Tests Failed      = 0
+   [runcts] OUT => [javatest.batch] Number of Tests with Errors = 0
+```
+
+### jms/ee
+
+```
+   [runcts] OUT => [javatest.batch] Completed running 207 tests.
+   [runcts] OUT => [javatest.batch] Number of Tests Passed      = 207
+   [runcts] OUT => [javatest.batch] Number of Tests Failed      = 0
+   [runcts] OUT => [javatest.batch] Number of Tests with Errors = 0
+```
+
+### jms/ee20
+
+```
+   [runcts] OUT => [javatest.batch] Completed running 72 tests.
+   [runcts] OUT => [javatest.batch] Number of Tests Passed      = 72
+   [runcts] OUT => [javatest.batch] Number of Tests Failed      = 0
+   [runcts] OUT => [javatest.batch] Number of Tests with Errors = 0
+```
+
+### jpa_appmanaged
+
+```
+   [runcts] OUT => [javatest.batch] Completed running 1749 tests.
+   [runcts] OUT => [javatest.batch] Number of Tests Passed      = 1749
+   [runcts] OUT => [javatest.batch] Number of Tests Failed      = 0
+   [runcts] OUT => [javatest.batch] Number of Tests with Errors = 0
+```
+
+### jpa_appmanagedNoTx
+
+```
+   [runcts] OUT => [javatest.batch] Completed running 1889 tests.
+   [runcts] OUT => [javatest.batch] Number of Tests Passed      = 1889
+   [runcts] OUT => [javatest.batch] Number of Tests Failed      = 0
+   [runcts] OUT => [javatest.batch] Number of Tests with Errors = 0
+```
+
+### jpa_pmservlet
+
+```
+   [runcts] OUT => [javatest.batch] Completed running 1897 tests.
+   [runcts] OUT => [javatest.batch] Number of Tests Passed      = 1897
+   [runcts] OUT => [javatest.batch] Number of Tests Failed      = 0
+   [runcts] OUT => [javatest.batch] Number of Tests with Errors = 0
+```
+
+### jpa_puservlet
+
+```
+   [runcts] OUT => [javatest.batch] Completed running 1887 tests.
+   [runcts] OUT => [javatest.batch] Number of Tests Passed      = 1887
+   [runcts] OUT => [javatest.batch] Number of Tests Failed      = 0
+   [runcts] OUT => [javatest.batch] Number of Tests with Errors = 0
+```
+
+### jpa_stateful3
+
+```
+   [runcts] OUT => [javatest.batch] Completed running 1749 tests.
+   [runcts] OUT => [javatest.batch] Number of Tests Passed      = 1749
+   [runcts] OUT => [javatest.batch] Number of Tests Failed      = 0
+   [runcts] OUT => [javatest.batch] Number of Tests with Errors = 0
+```
+
+### jpa_stateless3
+
+```
+   [runcts] OUT => [javatest.batch] Completed running 1899 tests.
+   [runcts] OUT => [javatest.batch] Number of Tests Passed      = 1899
+   [runcts] OUT => [javatest.batch] Number of Tests Failed      = 0
+   [runcts] OUT => [javatest.batch] Number of Tests with Errors = 0
+```
+
+### jsf
+
+```
+   Test Modules:
+   261 passed, 5 skipped
+
+   Old Faces TCK:
+   [INFO]      [exec] [javatest.batch] Completed running 5400 tests.
+   [INFO]      [exec] [javatest.batch] Number of Tests Passed      = 5400
+   [INFO]      [exec] [javatest.batch] Number of Tests Failed      = 0
+   [INFO]      [exec] [javatest.batch] Number of Tests with Errors = 0
+
+   Signature Test:
+   [INFO] Results:
+   [INFO]
+   [INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0
+```
+
+### jsonb
+
+```
+   From Jakarta EE 10 TCK zip:
+   [runcts] OUT => [javatest.batch] Completed running 18 tests.
+   [runcts] OUT => [javatest.batch] Number of Tests Passed      = 18
+   [runcts] OUT => [javatest.batch] Number of Tests Failed      = 0
+   [runcts] OUT => [javatest.batch] Number of Tests with Errors = 0
+
+   From standalone runner:
+   [INFO] Results:
+   [INFO]
+   [WARNING] Tests run: 295, Failures: 0, Errors: 0, Skipped: 5
+```
+
+### jsonp
+
+```
+   From Jakarta EE 10 TCK zip:
+   [runcts] OUT => [javatest.batch] Completed running 76 tests.
+   [runcts] OUT => [javatest.batch] Number of Tests Passed      = 76
+   [runcts] OUT => [javatest.batch] Number of Tests Failed      = 0
+   [runcts] OUT => [javatest.batch] Number of Tests with Errors = 0
+
+   From standalone runner:
+   [INFO] Results:
+   [INFO]
+   [INFO] Tests run: 179, Failures: 0, Errors: 0, Skipped: 0
+   Pluggability:
+   [INFO] Results:
+   [INFO]
+   [INFO] Tests run: 18, Failures: 0, Errors: 0, Skipped: 0
+```
+
+### jsp
+
+```
+   From Jakarta EE 10 TCK zip:
+   [runcts] OUT => [javatest.batch] Completed running 735 tests.
+   [runcts] OUT => [javatest.batch] Number of Tests Passed      = 735
+   [runcts] OUT => [javatest.batch] Number of Tests Failed      = 0
+   [runcts] OUT => [javatest.batch] Number of Tests with Errors = 0
+
+   From standalone runner:
+   [INFO]      [exec] [javatest.batch] Completed running 708 tests.
+   [INFO]      [exec] [javatest.batch] Number of Tests Passed      = 708
+   [INFO]      [exec] [javatest.batch] Number of Tests Failed      = 0
+   [INFO]      [exec] [javatest.batch] Number of Tests with Errors = 0
+```
+
+### jstl
+
+```
+   [runcts] OUT => [javatest.batch] Completed running 541 tests.
+   [runcts] OUT => [javatest.batch] Number of Tests Passed      = 541
+   [runcts] OUT => [javatest.batch] Number of Tests Failed      = 0
+   [runcts] OUT => [javatest.batch] Number of Tests with Errors = 0
+```
+
+### jta
+
+```
+   [runcts] OUT => [javatest.batch] Completed running 141 tests.
+   [runcts] OUT => [javatest.batch] Number of Tests Passed      = 141
+   [runcts] OUT => [javatest.batch] Number of Tests Failed      = 0
+   [runcts] OUT => [javatest.batch] Number of Tests with Errors = 0
+```
+
+### samples
+
+```
+   [runcts] OUT => [javatest.batch] Completed running 12 tests.
+   [runcts] OUT => [javatest.batch] Number of Tests Passed      = 12
+   [runcts] OUT => [javatest.batch] Number of Tests Failed      = 0
+   [runcts] OUT => [javatest.batch] Number of Tests with Errors = 0
+```
+
+### security
+
+```
+   [INFO]      [exec] [javatest.batch] Completed running 84 tests.
+   [INFO]      [exec] [javatest.batch] Number of Tests Passed      = 84
+   [INFO]      [exec] [javatest.batch] Number of Tests Failed      = 0
+   [INFO]      [exec] [javatest.batch] Number of Tests with Errors = 0
+
+   Signature Test
+
+   [INFO] Results:
+   [INFO]
+   [INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0
+```
+
+### servlet
+
+```
+   [runcts] OUT => [javatest.batch] Completed running 1739 tests.
+   [runcts] OUT => [javatest.batch] Number of Tests Passed      = 1739
+   [runcts] OUT => [javatest.batch] Number of Tests Failed      = 0
+   [runcts] OUT => [javatest.batch] Number of Tests with Errors = 0
+```
+
+### signaturetest/javaee
+
+```
+   [runcts] OUT => [javatest.batch] Completed running 4 tests.
+   [runcts] OUT => [javatest.batch] Number of Tests Passed      = 4
+   [runcts] OUT => [javatest.batch] Number of Tests Failed      = 0
+   [runcts] OUT => [javatest.batch] Number of Tests with Errors = 0
+```
+
+### soap
+
+```
+   [javatest.batch]
+   [javatest.batch] Completed running 447 tests.
+   [javatest.batch] Number of Tests Passed      = 447
+   [javatest.batch] Number of Tests Failed      = 0
+   [javatest.batch] Number of Tests with Errors = 0
+   [javatest.batch]
+```
+
+### tags
+
+```
+   [INFO]      [exec] [javatest.batch]
+   [INFO]      [exec] [javatest.batch] Completed running 542 tests.
+   [INFO]      [exec] [javatest.batch] Number of Tests Passed      = 542
+   [INFO]      [exec] [javatest.batch] Number of Tests Failed      = 0
+   [INFO]      [exec] [javatest.batch] Number of Tests with Errors = 0
+   [INFO]      [exec] [javatest.batch]
+```
+
+### webservices12
+
+```
+   [runcts] OUT => [javatest.batch] Completed running 242 tests.
+   [runcts] OUT => [javatest.batch] Number of Tests Passed      = 242
+   [runcts] OUT => [javatest.batch] Number of Tests Failed      = 0
+   [runcts] OUT => [javatest.batch] Number of Tests with Errors = 0
+```
+
+### webservices13
+
+```
+   [runcts] OUT => [javatest.batch] Completed running 53 tests.
+   [runcts] OUT => [javatest.batch] Number of Tests Passed      = 53
+   [runcts] OUT => [javatest.batch] Number of Tests Failed      = 0
+   [runcts] OUT => [javatest.batch] Number of Tests with Errors = 0
+```
+
+### websocket
+
+```
+   [runcts] OUT => [javatest.batch] Completed running 748 tests.
+   [runcts] OUT => [javatest.batch] Number of Tests Passed      = 748
+   [runcts] OUT => [javatest.batch] Number of Tests Failed      = 0
+   [runcts] OUT => [javatest.batch] Number of Tests with Errors = 0
+```
+
+### xa
+
+```
+   [runcts] OUT => [javatest.batch] Completed running 66 tests.
+   [runcts] OUT => [javatest.batch] Number of Tests Passed      = 66
+   [runcts] OUT => [javatest.batch] Number of Tests Failed      = 0
+   [runcts] OUT => [javatest.batch] Number of Tests with Errors = 0
+```
+
+### xml-ws
+
+```
+   [javatest.batch]
+   [javatest.batch] Completed running 954 tests.
+   [javatest.batch] Number of Tests Passed      = 954
+   [javatest.batch] Number of Tests Failed      = 0
+   [javatest.batch] Number of Tests with Errors = 0
+   [javatest.batch]
+```

--- a/enterprise/docs/modules/ROOT/pages/Release Notes/Overview.adoc
+++ b/enterprise/docs/modules/ROOT/pages/Release Notes/Overview.adoc
@@ -8,6 +8,7 @@ Detailed information about features and fixes in every release.
 
 *2024*
 
+* 2024 May - xref:Release Notes/Release Notes 6.14.0.adoc[Payara Enterprise 6.14.0]
 * 2024 April - xref:Release Notes/Release Notes 6.13.0.adoc[Payara Enterprise 6.13.0]
 * 2024 March - xref:Release Notes/Release Notes 6.12.0.adoc[Payara Enterprise 6.12.0]
 * 2024 February - xref:Release Notes/Release Notes 6.11.0.adoc[Payara Enterprise 6.11.0]

--- a/enterprise/docs/modules/ROOT/pages/Release Notes/Release Notes 6.14.0.adoc
+++ b/enterprise/docs/modules/ROOT/pages/Release Notes/Release Notes 6.14.0.adoc
@@ -1,0 +1,57 @@
+= Release notes - Payara Platform Enterprise 6.14.0
+
+== Supported APIs and Applications
+
+* Jakarta EE 10
+* Jakarta EE 10 Applications
+* MicroProfile 6.1
+
+== Improvements
+
+* [FISH-8216] Refactor to fix 'The Security Manager is deprecated and will be removed in a future release' Java 21 Compilation Error
+
+== Bug Fixes
+
+* [FISH-6456] Remove the HTTP/2 warning
+
+* [FISH-8273] Unable to delete System Properties via admin console
+
+* [FISH-8317] [Community Contribution - https://github.com/poikilotherm[poikilotherm]]  Microprofile Config NPE for profiled setting
+
+* [FISH-8482] Payara server admin console - Version number appears to remove any non-numerical character
+
+== Component Upgrades
+
+* [FISH-7239] Upgrade Santaurio XMLSEC to 4
+
+* [FISH-7964] Upgrade Metro to 4.0.3
+
+* [FISH-8503] Upgrade Javassist to 3.30.2-GA
+
+* [FISH-8504] Upgrade Classmate to 1.7.0
+
+* [FISH-8505] Upgrade Nimbus Jose JWT to 9.37.3
+
+* [FISH-8507] Upgrade STAX2 API to 4.2.2
+
+* [FISH-8548] Upgrade Wasp to 3.2.2
+
+* [FISH-8549] Upgrade Hibernate Validator to 8.0.1.Final
+
+* [FISH-8550] Upgrade Woodstox Core to 6.6.2
+
+* [FISH-8556] Upgrade VirtualBox JWS to 4.2.8
+
+* [FISH-8558] Upgrade ASM to 9.7
+
+* [FISH-8560] Upgrade Accessors Smart to 2.5.1
+
+* [FISH-8627] Upgrade Docker JDK 11 Image to 11.0.23
+
+* [FISH-8628] Upgrade Docker JDK 17 Image to 17.0.11
+
+* [FISH-8629] Upgrade Docker JDK 21 Image to 21.0.3
+
+* [FISH-8640] Upgrade Grizzly Gmbal API to 4.0.3
+
+* [FISH-8641] Upgrade Felix Web Console to 5.0.2

--- a/enterprise/docs/modules/ROOT/partials/eclipse-microprofile.adoc
+++ b/enterprise/docs/modules/ROOT/partials/eclipse-microprofile.adoc
@@ -1,5 +1,6 @@
 .Eclipse MicroProfile Certification
 * xref:Eclipse MicroProfile Certification/Overview.adoc[Overview]
+* xref:Eclipse MicroProfile Certification/6.14.0/Overview.adoc[6.14.0 TCK Results]
 * xref:Eclipse MicroProfile Certification/6.13.0/Overview.adoc[6.13.0 TCK Results]
 * xref:Eclipse MicroProfile Certification/6.12.0/Overview.adoc[6.12.0 TCK Results]
 * xref:Eclipse MicroProfile Certification/6.11.0/Overview.adoc[6.11.0 TCK Results]

--- a/enterprise/docs/modules/ROOT/partials/jakarta-ee.adoc
+++ b/enterprise/docs/modules/ROOT/partials/jakarta-ee.adoc
@@ -1,5 +1,10 @@
 .Jakarta EE Certification
 * xref:Jakarta EE Certification/Overview.adoc[Overview]
+* xref:Jakarta EE Certification/6.14.0[6.14.0]
+** xref:Jakarta EE Certification/6.14.0/6.14.0 Platform TCK Results.adoc[6.14.0 Platform TCK Results]
+** xref:Jakarta EE Certification/6.14.0/6.14.0 (Web Profile) Web TCK Results.adoc[6.14.0 (Web Profile) Web TCK Results]
+** xref:Jakarta EE Certification/6.14.0/6.14.0 Core TCK Results.adoc[6.14.0 Core TCK Results]
+** xref:Jakarta EE Certification/6.14.0/6.14.0 (Web Profile) Core TCK Results.adoc[6.14.0 (Web Profile) Core TCK Results]
 * xref:Jakarta EE Certification/6.13.0[6.13.0]
 ** xref:Jakarta EE Certification/6.13.0/6.13.0 Platform TCK Results.adoc[6.13.0 Platform TCK Results]
 ** xref:Jakarta EE Certification/6.13.0/6.13.0 (Web Profile) Web TCK Results.adoc[6.13.0 (Web Profile) Web TCK Results]

--- a/enterprise/docs/modules/ROOT/partials/release-notes.adoc
+++ b/enterprise/docs/modules/ROOT/partials/release-notes.adoc
@@ -1,5 +1,6 @@
 .Release Notes
 * xref:Release Notes/Overview.adoc[Overview]
+* xref:Release Notes/Release Notes 6.14.0.adoc[Release Notes 6.14.0]
 * xref:Release Notes/Release Notes 6.13.0.adoc[Release Notes 6.13.0]
 * xref:Release Notes/Release Notes 6.12.0.adoc[Release Notes 6.12.0]
 * xref:Release Notes/Release Notes 6.11.0.adoc[Release Notes 6.11.0]


### PR DESCRIPTION
FISH-8603 Payara Enterprise 6.14.0 Release Notes and TCK Results

Removing Opentracing as its no longer  part of MP 6.1 https://microprofile.io/compatible/6-1/#overview
