### PR TITLE
[FISH-8387] - Diagnostics tool documentation

### DIFF
--- a/enterprise/docs/modules/ROOT/nav.adoc
+++ b/enterprise/docs/modules/ROOT/nav.adoc
@@ -98,6 +98,7 @@
 *** xref:Technical Documentation/Payara Server Documentation/Command Reference/change-master-password.adoc[change-master-password]
 *** xref:Technical Documentation/Payara Server Documentation/Command Reference/clean-jbatch-repository.adoc[clean-jbatch-repository]
 *** xref:Technical Documentation/Payara Server Documentation/Command Reference/clear-cache.adoc[clear-cache]
+*** xref:Technical Documentation/Payara Server Documentation/Command Reference/collect-diagnostics.adoc[collect-diagnostics]
 *** xref:Technical Documentation/Payara Server Documentation/Command Reference/collect-log-files.adoc[collect-log-files]
 *** xref:Technical Documentation/Payara Server Documentation/Command Reference/configure-jms-cluster.adoc[configure-jms-cluster]
 *** xref:Technical Documentation/Payara Server Documentation/Command Reference/configure-lb-weight.adoc[configure-lb-weight]
@@ -525,6 +526,8 @@
 **** xref:Technical Documentation/Payara Server Documentation/Extensions/gRPC Support/Usage.adoc[Usage]
 ** xref:Technical Documentation/Payara Server Documentation/Payara Server Docker Image.adoc[Payara Server Docker Image]
 ** xref:Technical Documentation/Payara Server Documentation/Payara InSight.adoc[Payara InSight]
+** Diagnostics and Troubleshooting
+*** xref:Technical Documentation/Payara Server Documentation/Diagnostics and Troubleshooting/Diagnostics Tool.adoc[Diagnostics Tool]
 ** Upgrade Guide
 *** xref:Technical Documentation/Payara Server Documentation/Upgrade Guide/Overview.adoc[Overview]
 *** xref:Technical Documentation/Payara Server Documentation/Upgrade Guide/Upgrade Tool.adoc[Upgrade Tool]

--- a/enterprise/docs/modules/ROOT/pages/Technical Documentation/Payara Server Documentation/Command Reference/collect-diagnostics.adoc
+++ b/enterprise/docs/modules/ROOT/pages/Technical Documentation/Payara Server Documentation/Command Reference/collect-diagnostics.adoc
@@ -1,0 +1,144 @@
+[[collect-diagnostics]]
+= collect-diagnostics
+
+Collects data used for the diagnostics and troubleshooting of Payara Server incidents.
+
+[[synopsis]]
+== Synopsis
+
+[source,shell]
+----
+asadmin [asadmin-options] collect-diagnostics [--help]
+[--domainDir=directory]
+[--nodeDir=directory]
+[--target=target]
+[--dir=<file-path>]
+[--serverLog={false|true}]
+[--domainXml={false|true}]
+[--threadDump={false|true}]
+[--heapDump={false|true}]
+[--jvmReport={false|true}]
+[domainName]
+----
+
+[[description]]
+== Description
+
+This command will collect useful information for diagnosing incidents within a Payara Server domain.
+
+Among the data collected is the following information:
+
+* `domain.xml` configuration file
+* Server logs
+* A JVM thread dump.
+* A JVM Heap Dump
+* JVM Report
+
+NOTE: The data collected is stored in a ZIP file in your user home directory, the output directory by default.
+
+[[options]]
+== Options
+
+asadmin-options::
+Options for the `asadmin` utility. For information about these options, see the xref:docs::Technical Documentation/Payara Server Documentation/Command Reference/asadmin.adoc#asadmin-1m[`asadmin`] help page.
+`--help`::
+`-?`::
+Displays the help text for the subcommand.
+`--target`::
+This option helps specify the target on which data is collected. Valid values are: +
+deployment_group_name;;
+Applies to every server instance in the specified deployment group.
+cluster_name;;
+Applies to every server instance in the specified cluster.
+instance_name;;
+Applies to a specific sever instance.
+`--domainDir`::
+The path to the directory containing the target domain.
++
+Defaults to
+`as-install/glassfish/domains`
+`--nodeDir`::
+The path to the directory containing the target node.
++
+Defaults to `as-install/glassfish/nodes`
+`--dir`::
+The directory path where the ZIP file will be stored. Defaults to `$+{user.home}+`
+`--domainXml`::
+Whether to collect the `domain.xml` configuration file. Defaults to `true`.
+`--serverLog`::
+Whether to collect server logs. Defaults to `true`
+`--heapDump`::
+Whether to collect a heap dump. Defaults to `true`
+`--threadDump`::
+Whether to collect a thread dump. Defaults to `true`
+`--jvmReport`::
+Whether to collect the JVM report. Defaults to `true`
+
+[[operands]]
+== Operands
+
+domainName::
+The name of the domain that will be scanned.
++
+Defaults to `domain1`.
+
+[[examples]]
+== Examples
+
+*Example 1 Collect Diagnostics*
+
+The following example shows how to collect the data of all instances that belong to the `deploymentGroup1` deployment group in the `mydomain` domain:
+
+[source, shell]
+----
+asadmin collect-diagnostics --target deploymentGroup1 mydomain
+
+Directory selected /home/user/payara/diagnostics/mydomain-2024-04-15T11-42-36Z
+Collecting domain.xml from instance2
+Attempting to create missing path at /home/user/payara/diagnostics/mydomain-2024-04-15T11-42-36Z/deploymentGroup1/instance1
+Collecting logs from instance2
+Collecting jvm report from instance2
+Collecting thread dump from instance2
+Collecting Heap Dump from instance2
+This version of Payara does not support heap dump generation.
+Collecting domain.xml from instance1
+Attempting to create missing path at /home/user/payara/diagnostics/mydomain-2024-04-15T11-42-36Z/deploymentGroup1/instance1
+Collecting logs from instance1
+Collecting jvm report from instance1
+Collecting thread dump from instance1
+Collecting Heap Dump from instance1
+
+Command collect-diagnostics executed successfully.
+----
+
+*Example 2 Collect only a Heap Dump*
+
+The following example shows how to just collect a Heap dump of all instances in the `mydomain` domain:
+
+[source, shell]
+----
+asadmin collect-diagnostics --target deploymentGroup1 --threadDump=false --domainXml=false --jvmReport=false --serverLog=false mydomain
+
+Directory selected /home/user/payara/diagnostics/mydomain-2024-04-15T11-42-36Z
+Collecting domain.xml from instance2
+Attempting to create missing path at /home/user/payara/diagnostics/mydomain-2024-04-15T11-42-36Z/deploymentGroup1/instance1
+Collecting Heap Dump from instance2
+This version of Payara does not support heap dump generation.
+Collecting domain.xml from instance1
+Attempting to create missing path at /home/user/payara/diagnostics/mydomain-2024-04-15T11-42-36Z/deploymentGroup1/instance1
+Collecting Heap Dump from instance1
+
+Command collect-diagnostics executed successfully.
+----
+
+[[exit-status]]
+== Exit Status
+
+0::
+subcommand executed successfully
+1::
+error in executing the subcommand
+
+*See Also*
+
+* xref:Technical Documentation/Payara Server Documentation/Diagnostics and Troubleshooting/Diagnostics Tool.adoc[Diagnostics Tool]

--- a/enterprise/docs/modules/ROOT/pages/Technical Documentation/Payara Server Documentation/Diagnostics and Troubleshooting/Diagnostics Tool.adoc
+++ b/enterprise/docs/modules/ROOT/pages/Technical Documentation/Payara Server Documentation/Diagnostics and Troubleshooting/Diagnostics Tool.adoc
@@ -1,0 +1,80 @@
+[[diagnostics-tool]]
+= Diagnostics Tool
+
+Payara Server has a diagnostic tool that on demand collects the following information from the server runtime.
+
+* `domain.xml` configuration file
+* Server logs
+* A JVM thread dump.
+* A JVM Heap Dump
+* JVM Report
+
+The collection of this data can be targeted towards specific a specific server instance, deployment group or cluster. By default, everything is collected from the DAS, each instance, deployment group and cluster configured in the domain.
+
+If the target(s) is(are) offline, only the `domain.xml` configuration file and server logs will be collected.
+
+NOTE: If you are not using the default _domain1_, you must specify the domain to collect diagnostics from.
+
+[[usage]]
+== Usage
+
+The diagnostic tool can be used through the xref:Technical Documentation/Payara Server Documentation/Command Reference/collect-diagnostics.adoc#collect-diagnostics[`collect-diagnostics`] Asadmin CLI subcommand, which will collect the relevant data and store it locally in a ZIP bundle that can be used for troubleshooting purposes when raising support tickets on the support portal.
+
+Using this command will allow both customers and support staff to work faster on the investigation and analysis of production and development incidents.
+
+NOTE: The data collected is stored in a ZIP file in your user home directory, the output directory by default.
+
+The resulting compressed ZIP file will have a directory structure similar to the following:
+
+----
+deploymentGroup1
+├── instance1
+│   ├── instance1-domain.xml
+│   ├── instance1-jvm-report.txt
+│   ├── instance1-server.log
+│   └── instance1-thread-dump.txt
+└── instance2
+    ├── instance2-domain.xml
+    ├── instance2-jvm-report.txt
+    ├── instance2-server.log
+    └── instance2-thread-dump.txt
+----
+
+Where the data is grouped in sub-folders segregated in all targets (deployment groups, clusters and instances) scanned by the command.
+
+[[example]]
+=== Example
+
+The following example shows how to collect the data of all instances that belong to the `deploymentGroup1` deployment group in the `mydomain` domain:
+
+[source, shell]
+----
+asadmin> collect-diagnostics --target deploymentGroup1 mydomain
+
+Directory selected /home/user/payara/diagnostics/mydomain-2024-04-15T11-42-36Z
+Collecting domain.xml from instance2
+Attempting to create missing path at /home/user/payara/diagnostics/mydomain-2024-04-15T11-42-36Z/deploymentGroup1/instance1
+Collecting logs from instance2
+Collecting jvm report from instance2
+Collecting thread dump from instance2
+Collecting Heap Dump from instance2
+This version of Payara does not support heap dump generation.
+Collecting domain.xml from instance1
+Attempting to create missing path at /home/user/payara/diagnostics/mydomain-2024-04-15T11-42-36Z/deploymentGroup1/instance1
+Collecting logs from instance1
+Collecting jvm report from instance1
+Collecting thread dump from instance1
+Collecting Heap Dump from instance1
+
+Command collect-diagnostics executed successfully.
+----
+
+[[remote-collection]]
+== Remote Collection
+
+Diagnostics can be collected directly from a remote DAS by specifying the admin port of the target instance (see xref:docs::Technical Documentation/Payara Server Documentation/Command Reference/asadmin.adoc#options[Asadmin Options]), like this:
+
+[source, shell]
+----
+asadmin> -p 24848 collect-diagnostics --target deploymentGroup1 mydomain
+----


### PR DESCRIPTION
The counterpart of #435 for the Payara Platform 6.

Documentation of the latest diagnostic tool introduced for Payara Enterprise. Also documented the new command in the server's command reference.