### PR TITLE
[Payara 5 Documentation] Updated version numbers and installation instructions for Amazon SQS connectors

### DIFF
--- a/docs/modules/ROOT/pages/Technical Documentation/Ecosystem/Connector Suites/Cloud Connectors/Amazon SQS/Versioning.adoc
+++ b/docs/modules/ROOT/pages/Technical Documentation/Ecosystem/Connector Suites/Cloud Connectors/Amazon SQS/Versioning.adoc
@@ -11,7 +11,7 @@ This is the first version of the connector that is based on https://docs.aws.ama
 [[v1-usage]]
 === Usage
 
-The `amazon-sqs-rar-1.1.0.rar` JCA adapter has to be deployed as shown in the xref:/Technical Documentation/Ecosystem/Connector Suites/Cloud Connectors/Overview.adoc#Installing-a-connector[Installing a connector section] of the Cloud Connectors overview.
+The `amazon-sqs-rar-0.8.0.rar` JCA adapter has to be deployed as shown in the xref:/Technical Documentation/Ecosystem/Connector Suites/Cloud Connectors/Overview.adoc#Installing-a-connector[Installing a connector section] of the Cloud Connectors overview.
 
 Additionally, to use the connector API add the following Maven dependencies to your application's project:
 
@@ -20,7 +20,7 @@ Additionally, to use the connector API add the following Maven dependencies to y
 <dependency>
   <groupId>fish.payara.cloud.connectors.amazonsqs</groupId>
   <artifactId>amazon-sqs-jca-api</artifactId>
-  <version>[,1.1.0)</version>  
+  <version>0.8.0</version>
   <type>jar</type>
   <scope>provided</scope>
 </dependency>
@@ -34,7 +34,7 @@ Additionally, to use the connector API add the following Maven dependencies to y
 </dependency>
 ----
 
-NOTE: These dependencies have a provided `scope` since the types within this dependency are globally available to every application deployed to Payara Micro after the `amazon-sqs-rar-1.1.0.rar` has been deployed.
+NOTE: These dependencies have a provided `scope` since the types within this dependency are globally available to every application deployed to Payara Micro after the `amazon-sqs-rar-0.8.0.rar` has been deployed.
 
 WARNING: It can be confusing, but disregard the version of the artifact, as it constitutes a sequential development of the "first version" of the connector's artifact.
 
@@ -46,19 +46,7 @@ This is the second version of the connector that is based on https://docs.aws.am
 [[v2-usage]]
 === Usage
 
-[source, shell]
-----
-git clone git@github.com:payara/Cloud-Connectors.git
-cd Cloud-Connectors/
-git checkout tags/AmazonSQS-1.1.0
-mvn clean install
-----
-
-The connector's RAR artifact can be found in the following location:
-
-----
-./AmazonSQS/AmazonSQSRAR/target/amazon-sqs-rar-1.1.0.rar
-----
+The `amazon-sqs-rar-1.1.0.rar` JCA adapter can be downloaded from https://mvnrepository.com/artifact/fish.payara.cloud.connectors.amazonsqs/amazon-sqs-rar/1.1.0[Maven Central].
 
 Additionally, to use the connector API add the following Maven dependencies to your application's project:
 
@@ -67,7 +55,7 @@ Additionally, to use the connector API add the following Maven dependencies to y
 <dependency>
     <groupId>fish.payara.cloud.connectors.amazonsqs</groupId>
     <artifactId>amazon-sqs-jca-api</artifactId>
-    <version>1.0.0</version>
+    <version>1.1.0</version>
     <type>jar</type>
     <scope>provided</scope>
 </dependency>


### PR DESCRIPTION
Minor fixes related to the versions of the SQS connector and updated installation instructions, encouraging users to download the SQS connectors via Maven Central rather than building from source.