### PR TITLE
Fix payara-web-app Link

### DIFF
--- a/community/docs/antora.yml
+++ b/community/docs/antora.yml
@@ -7,7 +7,7 @@ nav:
 asciidoc:
   attributes:
     glassfishVersion: '5'
-    payaraWebDtd: 'https://docs.payara.fish/schemas/payara-web-app_4.dtd'
+    payaraWebDtd: 'https://raw.githubusercontent.com/payara/Payara-Documentation/refs/heads/main-6/docs/modules/ROOT/pages/Appendix/Schemas/payara-web-app_4.dtd'
     payaraResourcesDtd: 'https://raw.githubusercontent.com/payara/Payara-Documentation/master/docs/modules/ROOT/pages/Appendix/Schemas/payara-resources_1_7.dtd'
     # URL root for references to the docs for Payara Enterprise (mostly for enterprise-only features).
     # Use with the link: prefix, like link:{enterpriseDocsPageRootUrl}/readme.html, otherwise rendering outside Antora will be broken


### PR DESCRIPTION
The link to the DTD in the docs is incorrect, and just loops back to the front page.
This fixes it to point to the actual file.