### PR TITLE
ITOPS-4276 Add Deprecation notice to Maven Regex Profile Activation Extension

### DIFF
--- a/docs/modules/ROOT/pages/Technical Documentation/Ecosystem/Project Management Tools/Maven Regex Profile Activation.adoc
+++ b/docs/modules/ROOT/pages/Technical Documentation/Ecosystem/Project Management Tools/Maven Regex Profile Activation.adoc
@@ -3,6 +3,8 @@
 
 The Maven Regex Profile Activation extension allows activating profiles by checking that a property matches a given regular expression, rather than an exact value.
 
+WARNING: The Maven Regex Profile Activation Extension is deprecated and no longer supported. This extension will not recieve future updates.
+
 [[usage]]
 == Usage
 


### PR DESCRIPTION
As discussed with @abdulrahim458, the Maven Regex Profile Activation Extension is no longer being supported by Payara Engineering due to it being unused. This introduces a warning informing users.