### PR TITLE
Fixes to Payara DD DTD file links

### DIFF
--- a/community/docs/antora.yml
+++ b/community/docs/antora.yml
@@ -7,8 +7,8 @@ nav:
 asciidoc:
   attributes:
     glassfishVersion: '5'
-    payaraWebDtd: 'https://docs.payara.fish/schemas/payara-web-app_4.dtd'
-    payaraResourcesDtd: 'https://raw.githubusercontent.com/payara/Payara-Documentation/master/docs/modules/ROOT/pages/Appendix/Schemas/payara-resources_1_7.dtd'
+    payaraWebDtd: 'https://raw.githubusercontent.com/payara/Payara-Documentation/main-5/docs/modules/ROOT/pages/Appendix/Schemas/payara-web-app_4.dtd'
+    payaraResourcesDtd: 'https://raw.githubusercontent.com/payara/Payara-Documentation/main-5/docs/modules/ROOT/pages/Appendix/Schemas/payara-resources_1_7.dtd'
     # URL root for references to the docs for Payara Enterprise (mostly for enterprise-only features).
     # Use with the link: prefix, like link:{enterpriseDocsPageRootUrl}/readme.html, otherwise rendering outside Antora will be broken
     enterpriseDocsPageRootUrl: https://docs.payara.fish/enterprise/docs/

--- a/enterprise/docs/antora.yml
+++ b/enterprise/docs/antora.yml
@@ -7,8 +7,8 @@ nav:
 asciidoc:
   attributes:
     glassfishVersion: '5'
-    payaraWebDtd: 'https://raw.githubusercontent.com/payara/Payara-Documentation/master/docs/modules/ROOT/pages/Appendix/Schemas/payara-web-app_4.dtd'
-    payaraResourcesDtd: 'https://raw.githubusercontent.com/payara/Payara-Documentation/master/docs/modules/ROOT/pages/Appendix/Schemas/payara-resources_1_7.dtd'
+    payaraWebDtd: 'https://raw.githubusercontent.com/payara/Payara-Documentation/main-5/docs/modules/ROOT/pages/Appendix/Schemas/payara-web-app_4.dtd'
+    payaraResourcesDtd: 'https://raw.githubusercontent.com/payara/Payara-Documentation/main-5/docs/modules/ROOT/pages/Appendix/Schemas/payara-resources_1_7.dtd'
     mpConfigVersion: '2.0.1'
     mpConfigSpecUrl: 'https://github.com/eclipse/microprofile-config/releases/tag/2.0'
     mpMetricsVersion: '3.0.1'


### PR DESCRIPTION
Fixed links for the DTD schemas of the `payara-web.xml` and `payara-resources.xml` deployment descriptors.