### PR TITLE
FISH-10016 Update SNMP Library Versions in Notifier documentation

### DIFF
--- a/community/docs/modules/ROOT/pages/Technical Documentation/Payara Server Documentation/Extensions/Notifiers/SNMP.adoc
+++ b/community/docs/modules/ROOT/pages/Technical Documentation/Payara Server Documentation/Extensions/Notifiers/SNMP.adoc
@@ -8,9 +8,9 @@ The **S**imple **N**etwork **M**anagement **P**rotocol is a standard Internet Pr
 
 - link:https://nexus.payara.fish/repository/payara-artifacts/fish/payara/extensions/notifiers/snmp-notifier-core/2.0/snmp-notifier-core-2.0.jar[SNMP Notifier Core 2.0]
 - link:https://nexus.payara.fish/repository/payara-artifacts/fish/payara/extensions/notifiers/snmp-notifier-console-plugin/2.0/snmp-notifier-console-plugin-2.0.jar[SNMP Notifier Console Plugin 2.0]
-- link:https://nexus.payara.fish/repository/payara-artifacts/fish/payara/server/core/packager/snmp4j-repackaged/3.7.5/snmp4j-repackaged-3.7.5.jar[Dependency: SNMP4J 3.7.5]
+- link:https://nexus.payara.fish/repository/payara-artifacts/fish/payara/server/core/packager/snmp4j-repackaged/3.8.2/snmp4j-repackaged-3.8.2.jar[Dependency: SNMP4J 3.8.2]
 
-IMPORTANT: Use the version of SNMP4J 3.7.5 provided above as it has a modified manifest to be compatible with Payara Community.
+IMPORTANT: Use the version of SNMP4J 3.8.2 provided above as it has a modified manifest to be compatible with Payara Community.
 
 [[snmp-concepts]]
 == SNMP Concepts


### PR DESCRIPTION
- Updates the version numbers used in the Community documentation for the SNMP notifier from 3.7.5 to 3.8.2.
- Updates the URL to what is likely to be the URL for the next repackaged SNMP4J release.