### PR TITLE
FISH-9690: adding documentation for new grizzly properties to protect from RFC-9110 invalid characters

### DIFF
--- a/docs/modules/ROOT/pages/Technical Documentation/Payara Server Documentation/General Administration/Administering HTTP Connectivity.adoc
+++ b/docs/modules/ROOT/pages/Technical Documentation/Payara Server Documentation/General Administration/Administering HTTP Connectivity.adoc
@@ -1247,3 +1247,126 @@ A string value that specifies whether the `Secure` attribute is included in `JSE
 * `true` — The `Secure` attribute is included.
 * `false` — The `Secure` attribute is not included.
 * `dynamic` — The `Secure` attribute setting is inherited from the default ports table for all HTTP listeners first session participating in SSO. This is the default value.
+
+[[http-header-validation]]
+=== HTTP Header Validation
+
+The following options can help you to protect against invalid characters on the Http Header Name and Http Header Value content. You can follow the RFC-9110 documentation (See section 5.5 of: https://www.rfc-editor.org/rfc/rfc9110.html)  to understand more about the recommendations.
+
+IMPORTANT: Currently there is a reported CVE with number  https://www.cve.org/CVERecord?id=CVE-2024-45687[CVE-2024-45687] that indicates a risk when not protecting against invalid characters on the Header Name and Header Value content.
+
+The following options can be set on the Payara Server with the asadmin command as follows:
+
+*Invalid Characters*
+
+The following table summarize the list of invalid characters that can't be added on the Header Name and Header Value content from the RFC-9110 definition:
+
+
+.Invalid Characters RFC-9110
+|===
+|Character |Representation
+
+|NUL character
+|This character is expressed in the following forms on a literal value: \0  \x00 https://en.wikipedia.org/wiki/Null_character[review explanation here]
+
+|LF Character (new line)
+|This character is expressed in the following forms on a literal value: \n \x0A https://en.wikipedia.org/wiki/Newline[review explanation here]
+
+|CR Character (carriage return)
+|This character is expressed in the following forms on a literal value: \r \x0D https://en.wikipedia.org/wiki/Carriage_return[review explanation here]
+
+|===
+
+
+*Header Name validation*
+
+To protect against invalid characters on the Http Header Name you need to enable the following property:
+
+
+.Http Header Name Validation
+|===
+|Property |Description
+
+|org.glassfish.grizzly.http.STRICT_HEADER_NAME_VALIDATION_RFC_9110
+|This property enable the validation of the Header Name content to prevent any usage of invalid characters on it. By default, this property is set as false on the grizzly implementation. You need to set as true to enable Http Header Name content validation
+
+|===
+
+To set the property you can use the following command:
+
+[source,shell]
+----
+asadmin create-jvm-options --target=server-config "-Dorg.glassfish.grizzly.http.STRICT_HEADER_NAME_VALIDATION_RFC_9110\=true"
+----
+
+To test it you can make a call with curl adding an invalid Http Header Name using invalid characters:
+
+[source,shell]
+----
+curl -i -v -H "X-MyHeader\n: hello" myendpoint
+----
+
+The result of this call with the enabled property will be as follows:
+
+[source,shell]
+----
+< HTTP/1.1 400 Bad Request
+HTTP/1.1 400 Bad Request
+< Date: Wed, 13 Nov 2024 20:36:37 GMT
+Date: Wed, 13 Nov 2024 20:36:37 GMT
+< Connection: close
+Connection: close
+< Content-Length: 0
+Content-Length: 0
+< X-Frame-Options: SAMEORIGIN
+X-Frame-Options: SAMEORIGIN
+
+<
+* Closing connection 0
+----
+
+*Header Value validation*
+
+To protect against invalid characters on the Http Header Value you need to enable the following property:
+
+.Http Header Value Validation
+|===
+|Property |Description
+
+|org.glassfish.grizzly.http.STRICT_HEADER_VALUE_VALIDATION_RFC_9110
+|This property enable the validation of the Header Value content to prevent any usage of invalid characters on it. By default, this property is set as false on the grizzly implementation. You need to set as true to enable Http Header Value content validation
+
+|===
+
+To set the property you can use the following command:
+
+[source,shell]
+----
+asadmin create-jvm-options --target=server-config "-Dorg.glassfish.grizzly.http.STRICT_HEADER_VALUE_VALIDATION_RFC_9110\=true"
+----
+
+To test it you can make a call with curl adding an invalid Http Header Value using invalid characters:
+
+[source,shell]
+----
+curl -i -v -H "X-MyHeader: hello\n" myendpoint
+----
+
+The result of this call with the enabled property will be as follows:
+
+[source,shell]
+----
+< HTTP/1.1 400 Bad Request
+HTTP/1.1 400 Bad Request
+< Date: Wed, 13 Nov 2024 20:37:04 GMT
+Date: Wed, 13 Nov 2024 20:37:04 GMT
+< Connection: close
+Connection: close
+< Content-Length: 0
+Content-Length: 0
+< X-Frame-Options: SAMEORIGIN
+X-Frame-Options: SAMEORIGIN
+
+<
+* Closing connection 0
+----

--- a/docs/modules/ROOT/pages/Technical Documentation/Payara Server Documentation/General Administration/Administering HTTP Connectivity.adoc
+++ b/docs/modules/ROOT/pages/Technical Documentation/Payara Server Documentation/General Administration/Administering HTTP Connectivity.adoc
@@ -1249,58 +1249,47 @@ A string value that specifies whether the `Secure` attribute is included in `JSE
 * `dynamic` — The `Secure` attribute setting is inherited from the default ports table for all HTTP listeners first session participating in SSO. This is the default value.
 
 [[http-header-validation]]
-== HTTP Header Validation
+== HTTP Header Fields Validation
 
-The following options can help you to protect against invalid characters on the HTTP Header Name and HTTP Header Value content. You can follow the RFC-9110 documentation (See section 5.5 of: https://www.rfc-editor.org/rfc/rfc9110.html) to understand more about the recommendations.
+By default, The following characters are stipulated to be dangerous to parse in both the name and value of all headers passed down on an HTTP request:
 
-The following sections will describe how to configure the new options from Grizzly.
-
-*Invalid Characters*
-
-The following table summarize the list of invalid characters that can't be added on the Header Name and Header Value content from the RFC-9110 definition:
-
-
-.Invalid Characters RFC-9110
 |===
 |Character |Representation
 
 |NUL character
-|This character is expressed in the following forms on a literal value: \0  \x00 https://en.wikipedia.org/wiki/Null_character[review explanation here]
+|This character is expressed in the following forms on a literal value: `\0  \x00` https://en.wikipedia.org/wiki/Null_character[review explanation here]
 
 |LF Character (new line)
-|This character is expressed in the following forms on a literal value: \n \x0A https://en.wikipedia.org/wiki/Newline[review explanation here]
+|This character is expressed in the following forms on a literal value: `\n \x0A` https://en.wikipedia.org/wiki/Newline[review explanation here]
 
 |CR Character (carriage return)
-|This character is expressed in the following forms on a literal value: \r \x0D https://en.wikipedia.org/wiki/Carriage_return[review explanation here]
+|This character is expressed in the following forms on a literal value: `\r \x0D` https://en.wikipedia.org/wiki/Carriage_return[review explanation here]
 
 |===
 
+As stipulated in section 5.5 Field Values of the link:https://datatracker.ietf.org/doc/html/rfc9110#name-field-values[RFC-9110 specification], these characters are deemed invalid and as such the server, as recipient of the request WILL reject it automatically upon detecting the presence of these characters.
 
-*Header Name validation*
+NOTE: On previous RFC specifications that detailed HTTP 1.1 semantics these characters were considered *acceptable*, however starting on RFC-9110, the use of these characters is no longer acceptable for header fields names and values.
 
-To protect against invalid characters on the HTTP Header Name, now Grizzly is providing an option to enable this validation and by default is set as true. That means that you don't need to worry, but if this behaviour that protect you against those characters is not well to you, then you can disable by setting the property on the server.
+In some cases, it might be necessary for backwards compatibility to allow these characters to be processed by the server runtime, so the following Grizzly (HTTP) system properties allow header fields character validation to be turned on/off:
 
-
-.HTTP Header Name Validation
-|===
-|Property |Description
-
-|org.glassfish.grizzly.http.STRICT_HEADER_NAME_VALIDATION_RFC_9110
-|This property enable the validation of the Header Name content to prevent any usage of invalid characters on it. By default, this property is set as true on the Grizzly implementation. To disable you just need to set the value as false on the server.
-
-|===
-
-
-*Header Value validation*
-
-To protect against invalid characters on the HTTP Header Value, now Grizzly is providing an option to enable this validation and by default is set as true. That means that you don't need to worry, but if this behaviour that protect you against those characters is not well to you, then you can disable by setting the property on the server.
-
-.HTTP Header Value Validation
+.Grizzly Header Field Validation Properties
 |===
 |Property |Description
 
-|org.glassfish.grizzly.http.STRICT_HEADER_VALUE_VALIDATION_RFC_9110
-|This property enable the validation of the Header Value content to prevent any usage of invalid characters on it. By default, this property is set as true on the Grizzly implementation. To disable you just need to set the value as false on the server.
+|`org.glassfish.grizzly.http.STRICT_HEADER_NAME_VALIDATION_RFC_9110`
+|This property enable the validation of all header field names on incoming HTTP requests to prevent any usage of invalid characters on it.
+
+When set to `true` the presence of these characters will trigger the server to invalidate the request with a `400 - Bad Request` response.
+
+Set to `true` by default.
+
+|`org.glassfish.grizzly.http.STRICT_HEADER_VALUE_VALIDATION_RFC_9110`
+|This property enable the validation of all header field values on incoming HTTP requests to prevent any usage of invalid characters on it.
+
+When set to `true` the presence of these characters will trigger the server to invalidate the request with a `400 - Bad Request` response.
+
+Set to `true` by default.
 
 |===
 

--- a/docs/modules/ROOT/pages/Technical Documentation/Payara Server Documentation/General Administration/Administering HTTP Connectivity.adoc
+++ b/docs/modules/ROOT/pages/Technical Documentation/Payara Server Documentation/General Administration/Administering HTTP Connectivity.adoc
@@ -1249,13 +1249,13 @@ A string value that specifies whether the `Secure` attribute is included in `JSE
 * `dynamic` — The `Secure` attribute setting is inherited from the default ports table for all HTTP listeners first session participating in SSO. This is the default value.
 
 [[http-header-validation]]
-=== HTTP Header Validation
+== HTTP Header Validation
 
-The following options can help you to protect against invalid characters on the Http Header Name and Http Header Value content. You can follow the RFC-9110 documentation (See section 5.5 of: https://www.rfc-editor.org/rfc/rfc9110.html)  to understand more about the recommendations.
+The following options can help you to protect against invalid characters on the HTTP Header Name and HTTP Header Value content. You can follow the RFC-9110 documentation (See section 5.5 of: https://www.rfc-editor.org/rfc/rfc9110.html)  to understand more about the recommendations.
 
 IMPORTANT: Currently there is a reported CVE with number  https://www.cve.org/CVERecord?id=CVE-2024-45687[CVE-2024-45687] that indicates a risk when not protecting against invalid characters on the Header Name and Header Value content.
 
-The following options can be set on the Payara Server with the asadmin command as follows:
+The following sections will describe how to configure the new options from grizzly.
 
 *Invalid Characters*
 
@@ -1280,15 +1280,15 @@ The following table summarize the list of invalid characters that can't be added
 
 *Header Name validation*
 
-To protect against invalid characters on the Http Header Name you need to enable the following property:
+To protect against invalid characters on the HTTP Header Name you need to enable the following property:
 
 
-.Http Header Name Validation
+.HTTP Header Name Validation
 |===
 |Property |Description
 
 |org.glassfish.grizzly.http.STRICT_HEADER_NAME_VALIDATION_RFC_9110
-|This property enable the validation of the Header Name content to prevent any usage of invalid characters on it. By default, this property is set as false on the grizzly implementation. You need to set as true to enable Http Header Name content validation
+|This property enable the validation of the Header Name content to prevent any usage of invalid characters on it. By default, this property is set as false on the grizzly implementation. You need to set as true to enable HTTP Header Name content validation
 
 |===
 
@@ -1299,12 +1299,14 @@ To set the property you can use the following command:
 asadmin create-jvm-options --target=server-config "-Dorg.glassfish.grizzly.http.STRICT_HEADER_NAME_VALIDATION_RFC_9110\=true"
 ----
 
-To test it you can make a call with curl adding an invalid Http Header Name using invalid characters:
+To test it you can make a call with curl adding an invalid HTTP Header Name using invalid characters:
 
 [source,shell]
 ----
-curl -i -v -H "X-MyHeader\n: hello" myendpoint
+curl -i -v -H $'X-MyHeader\n: hello' myendpoint
 ----
+
+NOTE: The use of the $ symbol and the single quotes on the header descriptions permits to scape the special character. if you don't add you will send each character representation for example \r will be send as '\'char(0x5c) and 'r' char(0x72), not '\r' char(0x0d).
 
 The result of this call with the enabled property will be as follows:
 
@@ -1320,21 +1322,20 @@ Connection: close
 Content-Length: 0
 < X-Frame-Options: SAMEORIGIN
 X-Frame-Options: SAMEORIGIN
-
 <
 * Closing connection 0
 ----
 
 *Header Value validation*
 
-To protect against invalid characters on the Http Header Value you need to enable the following property:
+To protect against invalid characters on the HTTP Header Value you need to enable the following property:
 
-.Http Header Value Validation
+.HTTP Header Value Validation
 |===
 |Property |Description
 
 |org.glassfish.grizzly.http.STRICT_HEADER_VALUE_VALIDATION_RFC_9110
-|This property enable the validation of the Header Value content to prevent any usage of invalid characters on it. By default, this property is set as false on the grizzly implementation. You need to set as true to enable Http Header Value content validation
+|This property enable the validation of the Header Value content to prevent any usage of invalid characters on it. By default, this property is set as false on the grizzly implementation. You need to set as true to enable HTTP Header Value content validation
 
 |===
 
@@ -1345,11 +1346,11 @@ To set the property you can use the following command:
 asadmin create-jvm-options --target=server-config "-Dorg.glassfish.grizzly.http.STRICT_HEADER_VALUE_VALIDATION_RFC_9110\=true"
 ----
 
-To test it you can make a call with curl adding an invalid Http Header Value using invalid characters:
+To test it you can make a call with curl adding an invalid HTTP Header Value using invalid characters:
 
 [source,shell]
 ----
-curl -i -v -H "X-MyHeader: hello\n" myendpoint
+curl -i -v -H $'X-MyHeader: he\rllo' myendpoint
 ----
 
 The result of this call with the enabled property will be as follows:
@@ -1366,7 +1367,8 @@ Connection: close
 Content-Length: 0
 < X-Frame-Options: SAMEORIGIN
 X-Frame-Options: SAMEORIGIN
-
 <
 * Closing connection 0
 ----
+
+NOTE: In the case of HTTP Header Value validation this is less restrict than Header Name validation because it is possible to send multiple \n. This will cause to include new line on the value content.

--- a/docs/modules/ROOT/pages/Technical Documentation/Payara Server Documentation/General Administration/Administering HTTP Connectivity.adoc
+++ b/docs/modules/ROOT/pages/Technical Documentation/Payara Server Documentation/General Administration/Administering HTTP Connectivity.adoc
@@ -1251,9 +1251,7 @@ A string value that specifies whether the `Secure` attribute is included in `JSE
 [[http-header-validation]]
 == HTTP Header Validation
 
-The following options can help you to protect against invalid characters on the HTTP Header Name and HTTP Header Value content. You can follow the RFC-9110 documentation (See section 5.5 of: https://www.rfc-editor.org/rfc/rfc9110.html)  to understand more about the recommendations.
-
-IMPORTANT: Currently there is a reported CVE with number  https://www.cve.org/CVERecord?id=CVE-2024-45687[CVE-2024-45687] that indicates a risk when not protecting against invalid characters on the Header Name and Header Value content.
+The following options can help you to protect against invalid characters on the HTTP Header Name and HTTP Header Value content. You can follow the RFC-9110 documentation (See section 5.5 of: https://www.rfc-editor.org/rfc/rfc9110.html) to understand more about the recommendations.
 
 The following sections will describe how to configure the new options from grizzly.
 
@@ -1280,7 +1278,7 @@ The following table summarize the list of invalid characters that can't be added
 
 *Header Name validation*
 
-To protect against invalid characters on the HTTP Header Name you need to enable the following property:
+To protect against invalid characters on the HTTP Header Name, now Grizzly is providing an option to enable this validation and by default is set as true. That means that you don't need to worry, but if this behaviour that protect you against those characters is not well to you, then you can disable by setting the property on the server.
 
 
 .HTTP Header Name Validation
@@ -1288,87 +1286,22 @@ To protect against invalid characters on the HTTP Header Name you need to enable
 |Property |Description
 
 |org.glassfish.grizzly.http.STRICT_HEADER_NAME_VALIDATION_RFC_9110
-|This property enable the validation of the Header Name content to prevent any usage of invalid characters on it. By default, this property is set as false on the grizzly implementation. You need to set as true to enable HTTP Header Name content validation
+|This property enable the validation of the Header Name content to prevent any usage of invalid characters on it. By default, this property is set as true on the Grizzly implementation. To disable you just need to set the value as false on the server.
 
 |===
 
-To set the property you can use the following command:
-
-[source,shell]
-----
-asadmin create-jvm-options --target=server-config "-Dorg.glassfish.grizzly.http.STRICT_HEADER_NAME_VALIDATION_RFC_9110\=true"
-----
-
-To test it you can make a call with curl adding an invalid HTTP Header Name using invalid characters:
-
-[source,shell]
-----
-curl -i -v -H $'X-MyHeader\n: hello' myendpoint
-----
-
-NOTE: The use of the $ symbol and the single quotes on the header descriptions permits to scape the special character. if you don't add you will send each character representation for example \r will be send as '\'char(0x5c) and 'r' char(0x72), not '\r' char(0x0d).
-
-The result of this call with the enabled property will be as follows:
-
-[source,shell]
-----
-< HTTP/1.1 400 Bad Request
-HTTP/1.1 400 Bad Request
-< Date: Wed, 13 Nov 2024 20:36:37 GMT
-Date: Wed, 13 Nov 2024 20:36:37 GMT
-< Connection: close
-Connection: close
-< Content-Length: 0
-Content-Length: 0
-< X-Frame-Options: SAMEORIGIN
-X-Frame-Options: SAMEORIGIN
-<
-* Closing connection 0
-----
 
 *Header Value validation*
 
-To protect against invalid characters on the HTTP Header Value you need to enable the following property:
+To protect against invalid characters on the HTTP Header Value, now Grizzly is providing an option to enable this validation and by default is set as true. That means that you don't need to worry, but if this behaviour that protect you against those characters is not well to you, then you can disable by setting the property on the server.
 
 .HTTP Header Value Validation
 |===
 |Property |Description
 
 |org.glassfish.grizzly.http.STRICT_HEADER_VALUE_VALIDATION_RFC_9110
-|This property enable the validation of the Header Value content to prevent any usage of invalid characters on it. By default, this property is set as false on the grizzly implementation. You need to set as true to enable HTTP Header Value content validation
+|This property enable the validation of the Header Value content to prevent any usage of invalid characters on it. By default, this property is set as true on the Grizzly implementation. To disable you just need to set the value as false on the server.
 
 |===
 
-To set the property you can use the following command:
 
-[source,shell]
-----
-asadmin create-jvm-options --target=server-config "-Dorg.glassfish.grizzly.http.STRICT_HEADER_VALUE_VALIDATION_RFC_9110\=true"
-----
-
-To test it you can make a call with curl adding an invalid HTTP Header Value using invalid characters:
-
-[source,shell]
-----
-curl -i -v -H $'X-MyHeader: he\rllo' myendpoint
-----
-
-The result of this call with the enabled property will be as follows:
-
-[source,shell]
-----
-< HTTP/1.1 400 Bad Request
-HTTP/1.1 400 Bad Request
-< Date: Wed, 13 Nov 2024 20:37:04 GMT
-Date: Wed, 13 Nov 2024 20:37:04 GMT
-< Connection: close
-Connection: close
-< Content-Length: 0
-Content-Length: 0
-< X-Frame-Options: SAMEORIGIN
-X-Frame-Options: SAMEORIGIN
-<
-* Closing connection 0
-----
-
-NOTE: In the case of HTTP Header Value validation this is less restrict than Header Name validation because it is possible to send multiple \n. This will cause to include new line on the value content.

--- a/docs/modules/ROOT/pages/Technical Documentation/Payara Server Documentation/General Administration/Administering HTTP Connectivity.adoc
+++ b/docs/modules/ROOT/pages/Technical Documentation/Payara Server Documentation/General Administration/Administering HTTP Connectivity.adoc
@@ -1253,7 +1253,7 @@ A string value that specifies whether the `Secure` attribute is included in `JSE
 
 The following options can help you to protect against invalid characters on the HTTP Header Name and HTTP Header Value content. You can follow the RFC-9110 documentation (See section 5.5 of: https://www.rfc-editor.org/rfc/rfc9110.html) to understand more about the recommendations.
 
-The following sections will describe how to configure the new options from grizzly.
+The following sections will describe how to configure the new options from Grizzly.
 
 *Invalid Characters*
 


### PR DESCRIPTION
this is documentation for new properties added on the grizzly implementation to protect against RFC-9110 invalid characters on the Http Header Name and Http Header Validation 