### PR TITLE
Updated local playbooks to use v2.0 Antora custom theme.

### DIFF
--- a/community-local-playbook.yml
+++ b/community-local-playbook.yml
@@ -15,7 +15,7 @@ asciidoc:
     page-site-edition: 'community'
 ui:
   bundle:
-    url: https://github.com/payara/antora-ui-default/releases/download/v1.1/ui-bundle.zip
+    url: https://github.com/payara/antora-ui-default/releases/download/v2.0/ui-bundle.zip
     snapshot: true
 runtime:
   fetch: true

--- a/enterprise-local-playbook.yml
+++ b/enterprise-local-playbook.yml
@@ -15,7 +15,7 @@ asciidoc:
     page-site-edition: 'enterprise'
 ui:
   bundle:
-    url: https://github.com/payara/antora-ui-default/releases/download/v1.1/ui-bundle.zip
+    url: https://github.com/payara/antora-ui-default/releases/download/v2.0/ui-bundle.zip
     snapshot: true
 runtime:
   fetch: true


### PR DESCRIPTION
Bumped the version of the Antora theme used to build the HTML site to the newly published `v2.0` release.