### PR TITLE
FISH-8302 Describe Configuration of Virtual Threads in Concurrency Resources

### DIFF
--- a/docs/modules/ROOT/pages/Technical Documentation/Payara Server Documentation/Command Reference/create-managed-executor-service.adoc
+++ b/docs/modules/ROOT/pages/Technical Documentation/Payara Server Documentation/Command Reference/create-managed-executor-service.adoc
@@ -21,6 +21,7 @@ asadmin [asadmin-options] create-managed-executor-service [--help]
         [--keepaliveseconds keepaliveseconds]
         [--threadlifetimeseconds threadlifetimeseconds]
         [--taskqueuecapacity taskqueuecapacity]
+        [--usevirtualthreads={false|true}]
         [--description description]
         [--property property]
         [--target target]
@@ -74,6 +75,10 @@ Specifies the number of seconds that threads can remain in a thread pool before 
 The default value is 0, which means that threads are never purged.
 `--taskqueuecapacity`::
 Specifies the number of submitted tasks that can be stored in the task queue awaiting execution. The default value is 2147483647, which means that the task queue is essentially unbounded and can store any number of submitted tasks.
+`--usevirtualthreads`::
+If enabled, virtual threads will be used instead of the default thread pool. They provide a quick creation, minimal overhead and fast thread switching, but executed on a limited "carrying threads". Use virtual threads for tasks, which depend on external resources like database, microservices etc. Do not use them for long calculation. Available only on Java 21 and later.
++
+The default value is `false`.
 `--description`::
 Descriptive details about the resource.
 `--property`::

--- a/docs/modules/ROOT/pages/Technical Documentation/Payara Server Documentation/Command Reference/create-managed-executor-service.adoc
+++ b/docs/modules/ROOT/pages/Technical Documentation/Payara Server Documentation/Command Reference/create-managed-executor-service.adoc
@@ -76,7 +76,7 @@ The default value is 0, which means that threads are never purged.
 `--taskqueuecapacity`::
 Specifies the number of submitted tasks that can be stored in the task queue awaiting execution. The default value is 2147483647, which means that the task queue is essentially unbounded and can store any number of submitted tasks.
 `--usevirtualthreads`::
-If enabled, virtual threads will be used instead of the default thread pool. They provide a quick creation, minimal overhead and fast thread switching, but executed on a limited "carrying threads". Use virtual threads for tasks, which depend on external resources like database, microservices etc. Do not use them for long calculation. Available only on Java 21 and later.
+If enabled, virtual threads will be used instead of the default platform thread pool. They provide quick creation, minimal overhead, and fast thread switching, but are executed on limited "carrying threads". Use virtual threads for tasks which depend on external resources like databases, micro-services, etc. Do not use them for long calculation.
 +
 The default value is `false`.
 `--description`::

--- a/docs/modules/ROOT/pages/Technical Documentation/Payara Server Documentation/Command Reference/create-managed-scheduled-executor-service.adoc
+++ b/docs/modules/ROOT/pages/Technical Documentation/Payara Server Documentation/Command Reference/create-managed-scheduled-executor-service.adoc
@@ -69,7 +69,7 @@ Specifies the number of seconds that threads can remain in a thread pool before 
 +
 The default value is 0, which means that threads are never purged.
 `--usevirtualthreads`::
-If enabled, virtual threads will be used instead of the default thread pool. They provide a quick creation, minimal overhead and fast thread switching, but executed on a limited "carrying threads". Use virtual threads for tasks, which depend on external resources like database, microservices etc. Do not use them for long calculation. Available only on Java 21 and later.
+If enabled, virtual threads will be used instead of the default platform thread pool. They provide quick creation, minimal overhead, and fast thread switching, but are executed on limited "carrying threads". Use virtual threads for tasks which depend on external resources like databases, micro-services, etc. Do not use them for long calculation.
 +
 The default value is `false`.
 `--description`::

--- a/docs/modules/ROOT/pages/Technical Documentation/Payara Server Documentation/Command Reference/create-managed-scheduled-executor-service.adoc
+++ b/docs/modules/ROOT/pages/Technical Documentation/Payara Server Documentation/Command Reference/create-managed-scheduled-executor-service.adoc
@@ -18,7 +18,7 @@ asadmin [asadmin-options] create-managed-scheduled-executor-service [--help]
         [--corepoolsize corepoolsize]
         [--keepaliveseconds keepaliveseconds]
         [--threadlifetimeseconds threadlifetimeseconds]
-        [--taskqueuecapacity taskqueuecapacity]
+        [--usevirtualthreads={false|true}]
         [--description description]
         [--property property]
         [--target target]
@@ -68,6 +68,10 @@ The default value is 60.
 Specifies the number of seconds that threads can remain in a thread pool before being purged, regardless of whether the number of threads is greater than `corepoolsize` or whether the threads are idle.
 +
 The default value is 0, which means that threads are never purged.
+`--usevirtualthreads`::
+If enabled, virtual threads will be used instead of the default thread pool. They provide a quick creation, minimal overhead and fast thread switching, but executed on a limited "carrying threads". Use virtual threads for tasks, which depend on external resources like database, microservices etc. Do not use them for long calculation. Available only on Java 21 and later.
++
+The default value is `false`.
 `--description`::
 Descriptive details about the resource.
 `--property`::

--- a/docs/modules/ROOT/pages/Technical Documentation/Payara Server Documentation/Command Reference/create-managed-thread-factory.adoc
+++ b/docs/modules/ROOT/pages/Technical Documentation/Payara Server Documentation/Command Reference/create-managed-thread-factory.adoc
@@ -13,6 +13,7 @@ asadmin [asadmin-options] create-managed-thread-factory [--help]
         [--contextinfoenabled={false|true}]
         [--contextinfo={Classloader|JNDI|Security|WorkArea}]
         [--threadpriority threadpriority]
+        [--usevirtualthreads={false|true}]
         [--description description]
         [--property property]
         [--target target]
@@ -50,6 +51,10 @@ All contexts are propagated by default.
 Specifies the priority to assign to created threads.
 +
 The default value is 5.
+`--usevirtualthreads`::
+If enabled, virtual threads will be used instead of the default thread pool. They provide a quick creation, minimal overhead and fast thread switching, but executed on a limited "carrying threads". Use virtual threads for tasks, which depend on external resources like database, microservices etc. Do not use them for long calculation. Available only on Java 21 and later.
++
+The default value is `false`.
 `--description`::
 Descriptive details about the resource.
 `--property`::

--- a/docs/modules/ROOT/pages/Technical Documentation/Payara Server Documentation/Command Reference/create-managed-thread-factory.adoc
+++ b/docs/modules/ROOT/pages/Technical Documentation/Payara Server Documentation/Command Reference/create-managed-thread-factory.adoc
@@ -52,7 +52,7 @@ Specifies the priority to assign to created threads.
 +
 The default value is 5.
 `--usevirtualthreads`::
-If enabled, virtual threads will be used instead of the default thread pool. They provide a quick creation, minimal overhead and fast thread switching, but executed on a limited "carrying threads". Use virtual threads for tasks, which depend on external resources like database, microservices etc. Do not use them for long calculation. Available only on Java 21 and later.
+If enabled, virtual threads will be used instead of the default platform thread pool. They provide quick creation, minimal overhead, and fast thread switching, but are executed on limited "carrying threads". Use virtual threads for tasks which depend on external resources like databases, micro-services, etc. Do not use them for long calculation.
 +
 The default value is `false`.
 `--description`::


### PR DESCRIPTION
Describing configuration of virtual threads in MES, MSES, MFT.

Also remove obvious copy&paste error, `taskqueuecapacity` in MSES.