### PR TITLE
FISH-10828 - mention junit5 with arquillian connector for P7

### DIFF
--- a/docs/modules/ROOT/pages/Technical Documentation/Ecosystem/Connector Suites/Arquillian Containers/Overview.adoc
+++ b/docs/modules/ROOT/pages/Technical Documentation/Ecosystem/Connector Suites/Arquillian Containers/Overview.adoc
@@ -40,3 +40,5 @@ NOTE: For Payara Platform 6.x, adapters in version `3.x` are compatible.
 An example application demonstrating how to create a test suite that runs the tests inside various Payara Platform distributions using Arquillian can be seen in the https://github.com/payara/Payara-Examples[Payara Examples] repository.
 
 See specifically the https://github.com/payara/Payara-Examples/tree/master/ecosystem/arquillian-example[ecosystem/arquillian-example] subproject for an example of writing integration tests using Arquillian along with the corresponding container adapters described above.
+
+Arquillian requires Junit4, but also offers a version compatible with Junit5. The Payara Arquillian connector remains compatible with this version of Arquillian. See https://github.com/payara/Payara-Examples/tree/master/ecosystem/arquillian-junit5-example[ecosystem/arquillian-junit5-example] subproject for the same integration test mentioned above, adapted to work with Junit5.

--- a/docs/modules/ROOT/pages/Technical Documentation/Ecosystem/Connector Suites/Arquillian Containers/Overview.adoc
+++ b/docs/modules/ROOT/pages/Technical Documentation/Ecosystem/Connector Suites/Arquillian Containers/Overview.adoc
@@ -41,4 +41,4 @@ An example application demonstrating how to create a test suite that runs the te
 
 See specifically the https://github.com/payara/Payara-Examples/tree/master/ecosystem/arquillian-example[ecosystem/arquillian-example] subproject for an example of writing integration tests using Arquillian along with the corresponding container adapters described above.
 
-Arquillian requires Junit4, but also offers a version compatible with Junit5. The Payara Arquillian connector remains compatible with this version of Arquillian. See https://github.com/payara/Payara-Examples/tree/master/ecosystem/arquillian-junit5-example[ecosystem/arquillian-junit5-example] subproject for the same integration test mentioned above, adapted to work with Junit5.
+Arquillian requires Junit4, but also offers a version compatible with Junit5. The Payara Arquillian connector remains compatible with this version of Arquillian. See https://github.com/payara/Payara-Examples/tree/Payara6/ecosystem/arquillian-junit5-example[ecosystem/arquillian-junit5-example] subproject for the same integration test mentioned above, adapted to work with Junit5.


### PR DESCRIPTION
This adds a paragraph mentioning that Payara Arquillian connectors work with Arquillian-junit5, with a link to an example using junit5 (the link will work only after the new subproject is merged, see https://github.com/payara/Payara-Examples/pull/205)