### PR TITLE
FISH-11138 - updated deploy documentation

### DIFF
--- a/docs/modules/ROOT/pages/Technical Documentation/Payara Server Documentation/Command Reference/deploy.adoc
+++ b/docs/modules/ROOT/pages/Technical Documentation/Payara Server Documentation/Command Reference/deploy.adoc
@@ -121,10 +121,12 @@ asadmin-options::
   For stateful session bean instances, the persistence type without high availability is set in the server (the `sfsb-persistence-type` attribute) and must be set to `file`, which is the default and recommended value. +
   If any active web session, SFSB instance, or EJB timer fails to be preserved or restored, none of these will be available when the redeployment is complete. However, the redeployment continues and a warning is logged. +
   To preserve active state data, Payara Server serializes the data and saves it in memory. To restore the data, the class loader of the newly redeployed application deserializes the data that was previously saved.
-`--warlibs`::
-  If set to true, enables an application to make use of shared libraries installed to `domain_dir/lib/warlibs`.
-  Default is false.
-  This parameter takes precedence over enabling warlibs in --properties.
+ifeval::["{page-site-edition}" == "community"]
+  `--warlibs`::
+    If set to true, enables an application to make use of shared libraries installed to `domain_dir/lib/warlibs`.
+    Default is false.
+    This parameter takes precedence over enabling warlibs in --properties.
+endif::[]
 `--libraries`::
   A comma-separated list of library JAR files. Specify the library JAR files by their relative or absolute paths. Specify relative paths relative to domain-dir`/lib/applibs`. The libraries are made available to the application in the order specified.
 `--target`::

--- a/docs/modules/ROOT/pages/Technical Documentation/Payara Server Documentation/Command Reference/deploy.adoc
+++ b/docs/modules/ROOT/pages/Technical Documentation/Payara Server Documentation/Command Reference/deploy.adoc
@@ -35,7 +35,9 @@ asadmin [asadmin-options] deploy [--help]
 [--type pkg-type]
 [--properties(name=value)[:name=value]*]
 [--skipdsfailure]
-[--warlibs={false|true}]
+ifeval::["{page-site-edition}" == "community"]
+  [--warlibs={false|true}]
+endif::[]
 [file_archive|filepath]
 ----
 

--- a/docs/modules/ROOT/pages/Technical Documentation/Payara Server Documentation/Command Reference/deploy.adoc
+++ b/docs/modules/ROOT/pages/Technical Documentation/Payara Server Documentation/Command Reference/deploy.adoc
@@ -36,7 +36,7 @@ asadmin [asadmin-options] deploy [--help]
 [--properties(name=value)[:name=value]*]
 [--skipdsfailure]
 ifeval::["{page-site-edition}" == "community"]
-  [--warlibs={false|true}]
+[--warlibs={false|true}]
 endif::[]
 [file_archive|filepath]
 ----

--- a/docs/modules/ROOT/pages/Technical Documentation/Payara Server Documentation/Command Reference/deploy.adoc
+++ b/docs/modules/ROOT/pages/Technical Documentation/Payara Server Documentation/Command Reference/deploy.adoc
@@ -35,6 +35,7 @@ asadmin [asadmin-options] deploy [--help]
 [--type pkg-type]
 [--properties(name=value)[:name=value]*]
 [--skipdsfailure]
+[--warlibs={false|true}]
 [file_archive|filepath]
 ----
 
@@ -120,6 +121,10 @@ asadmin-options::
   For stateful session bean instances, the persistence type without high availability is set in the server (the `sfsb-persistence-type` attribute) and must be set to `file`, which is the default and recommended value. +
   If any active web session, SFSB instance, or EJB timer fails to be preserved or restored, none of these will be available when the redeployment is complete. However, the redeployment continues and a warning is logged. +
   To preserve active state data, Payara Server serializes the data and saves it in memory. To restore the data, the class loader of the newly redeployed application deserializes the data that was previously saved.
+`--warlibs`::
+  If set to true, enables an application to make use of shared libraries installed to `domain_dir/lib/warlibs`.
+  Default is false.
+  This parameter takes precedence over enabling warlibs in --properties.
 `--libraries`::
   A comma-separated list of library JAR files. Specify the library JAR files by their relative or absolute paths. Specify relative paths relative to domain-dir`/lib/applibs`. The libraries are made available to the application in the order specified.
 `--target`::
@@ -171,6 +176,7 @@ asadmin-options::
 
 ifeval::["{page-site-edition}" == "community"]
   `warlibs={false|true}`;;
+      (This property will be overriden by `--warlibs`)
       If set to true, enables an application to make use of shared libraries installed to `domain_dir/lib/warlibs`. Default is `false`. +
       Libraries stored in this directory allows a developer to create and deploy skinny WARs, as the libraries stored in this directory are subject to additional annotation and extension scanning & processing for CDI, EJB, Servlet, and more.
       Unlike common and application libraries (those stored in `domain_dir/lib` and `domain_dir/lib/applibs` respectively), warlibs are cached and don't dynamically update if the files within the directory are modified.


### PR DESCRIPTION
I have updated the documentation to reflect on the warlib changes. 

I have added that `--warlibs` takes precedence over `--properties warlibs` .